### PR TITLE
Update `pandas` minimum version to `2.1.0` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=2.0.0
-pandas>=1.5.1
+pandas>=2.1.0
 polars>=0.16.14
 scikit-learn>=1.2.2
 pyarrow>=11.0.0


### PR DESCRIPTION
Lower pandas version may throw an error `AttributeError: 'DataFrame' object has no attribute 'map'` (rising from `__replace_values_df` function in the file `preprocess.py`). 

This was changed in pandas version `2.1.0` where `map` function was provided on dataframe and `applymap` was  deprecated.