### PR TITLE
 UserWarning: `torch._utils.is_compiling` is deprecated. Use `torch.compiler.is_compiling` instead.

### DIFF
--- a/dicee/models/adopt.py
+++ b/dicee/models/adopt.py
@@ -278,7 +278,7 @@ def _single_tensor_adopt(
         step_t = state_steps[i]
 
         # If compiling, the compiler will handle cudagraph checks, see note [torch.compile x capturable]
-        if not torch._utils.is_compiling() and capturable:
+        if not torch.compiler.is_compiling() and capturable:
             capturable_supported_devices = _get_capturable_supported_devices()
             assert (
                 param.device.type == step_t.device.type
@@ -352,7 +352,7 @@ def _multi_tensor_adopt(
         )
 
     # If compiling, the compiler will handle cudagraph checks, see note [torch.compile x capturable]
-    if not torch._utils.is_compiling() and capturable:
+    if not torch.compiler.is_compiling() and capturable:
         capturable_supported_devices = _get_capturable_supported_devices(
             supports_xla=False
         )
@@ -407,7 +407,7 @@ def _multi_tensor_adopt(
             # If steps are on CPU, foreach will fall back to the slow path, which is a for-loop calling t.add(1) over
             # and over. 1 will then be wrapped into a Tensor over and over again, which is slower than if we just
             # wrapped it once now. The alpha is required to assure we go to the right overload.
-            if not torch._utils.is_compiling() and device_state_steps[0].is_cpu:
+            if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
                 torch._foreach_add_(
                     device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
                 )
@@ -440,7 +440,7 @@ def _multi_tensor_adopt(
         # If steps are on CPU, foreach will fall back to the slow path, which is a for-loop calling t.add(1) over
         # and over. 1 will then be wrapped into a Tensor over and over again, which is slower than if we just
         # wrapped it once now. The alpha is required to assure we go to the right overload.
-        if not torch._utils.is_compiling() and device_state_steps[0].is_cpu:
+        if not torch.compiler.is_compiling() and device_state_steps[0].is_cpu:
             torch._foreach_add_(
                 device_state_steps, torch.tensor(1.0, device="cpu"), alpha=1.0
             )
@@ -495,7 +495,7 @@ def adopt(
 
     # this check is slow during compilation, so we skip it
     # if it's strictly needed we can add this check back in dynamo
-    if not torch._utils.is_compiling() and not all(
+    if not torch.compiler.is_compiling() and not all(
         isinstance(t, torch.Tensor) for t in state_steps
     ):
         raise RuntimeError(

--- a/tests/test_adopt_optim.py
+++ b/tests/test_adopt_optim.py
@@ -1,0 +1,35 @@
+from dicee.executer import Execute
+import pytest
+from dicee.config import Namespace
+
+class TestRegressionAdoptOptim:
+    @pytest.mark.filterwarnings('ignore::UserWarning')
+    def test_adpot_optim(self):
+        args = Namespace()
+        args.model = 'Keci'
+        args.optim = 'Adopt'
+        args.dataset_dir = 'KGs/UMLS'
+        args.num_epochs = 20
+        args.batch_size = 1024
+        args.lr = 0.01
+        args.embedding_dim = 32
+        args.eval_model = 'train_val_test'
+        args.scoring_technique = 'KvsAll'
+        adopt_result = Execute(args).start()
+        assert 0.58 >= adopt_result['Val']['H@1'] >= 0.01
+
+        args = Namespace()
+        args.model = 'Keci'
+        args.optim = 'Adam'
+        args.dataset_dir = 'KGs/UMLS'
+        args.num_epochs = 20
+        args.batch_size = 1024
+        args.lr = 0.01
+        args.embedding_dim = 32
+        args.eval_model = 'train_val_test'
+        args.scoring_technique = 'KvsAll'
+        adam_result = Execute(args).start()
+        assert 0.58 >= adopt_result['Val']['H@1'] >= 0.01
+
+        assert adopt_result['Val']['MRR'] >= adam_result['Val']['MRR']
+        assert adopt_result['Train']['MRR'] >= adam_result['Train']['MRR']


### PR DESCRIPTION
Adopt optimizer uses  `torch._utils.is_compiling` , which is now deprecated. This update replaces that with `torch.compiler.is_compiling`, which is recommended by PyTorch. 