### PR TITLE
Fix installation instructions in README for clarity and correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ Deploy a pre-trained embedding model without writing a single line of code.
 ### Installation from Source
 ``` bash
 git clone https://github.com/dice-group/dice-embeddings.git
-conda create -n dice python=3.10.13 --no-default-packages && conda activate dice && pip3 install -e .
+
+conda create -n dice python=3.10.13 --no-default-packages && conda activate dice
+
+cd dice-embeddings
+
+pip3 install -e .
 # or
 pip3 install -e .["dev"]
 ```

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ Deploy a pre-trained embedding model without writing a single line of code.
 ### Installation from Source
 ``` bash
 git clone https://github.com/dice-group/dice-embeddings.git
-
-conda create -n dice python=3.10.13 --no-default-packages && conda activate dice
-
 cd dice-embeddings
 
-pip3 install -e .
+conda create -n dice python=3.10.13 --no-default-packages
+conda activate dice
+
+pip install -e .              # installs core dependencies
 # or
-pip3 install -e .["dev"]
+pip install -e '.[dev]'       # installs core + dev dependencies
+
 ```
 or
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,15 +44,9 @@ Deploy a pre-trained embedding model without writing a single line of code.
 ### Installation from Source
 ``` bash
 git clone https://github.com/dice-group/dice-embeddings.git
-cd dice-embeddings
-
-conda create -n dice python=3.10.13 --no-default-packages
-conda activate dice
-
-pip install -e .              # installs core dependencies
+cd dice-embeddings && conda create -n dice python=3.10.13 --no-default-packages && conda activate dice && pip install -e .
 # or
 pip install -e '.[dev]'       # installs core + dev dependencies
-
 ```
 or
 ```bash


### PR DESCRIPTION
### This PR updates the README installation steps by:

- Adding the missing `cd dice-embeddings` step.
- Fixing incorrect pip syntax (`.[dev]` now properly quoted).
- Improving overall clarity and consistency.