### PR TITLE
Moved psutil to core dependencies

### DIFF
--- a/dicee/read_preprocess_save_load_kg/util.py
+++ b/dicee/read_preprocess_save_load_kg/util.py
@@ -7,7 +7,7 @@ import functools
 import pandas as pd
 import pickle
 import os
-
+import psutil
 import requests
 from typing import Tuple
 import polars as pl
@@ -132,11 +132,6 @@ def apply_reciprocal_or_noise(add_reciprocal: bool, eval_model: str, df: object 
 
 
 def timeit(func):
-    try:
-        import psutil
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError('psutil is required for memory profiling but is part of the optional dependencies.'
-                                  ' Install it via `pip install psutil`')
     @functools.wraps(func)
     def timeit_wrapper(*args, **kwargs):
         start_time = time.perf_counter()

--- a/dicee/static_funcs.py
+++ b/dicee/static_funcs.py
@@ -13,7 +13,7 @@ import pickle
 import time
 from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Tuple, Type, Union
-
+import psutil
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -135,11 +135,6 @@ def timeit(func: Callable) -> Callable:
     Returns:
         Wrapped function that prints timing information.
     """
-    try:
-        import psutil
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError("psutil is required for the timeit decorator but is part of the optional dependencies."
-                                  " Please install it via 'pip install psutil'.")
     @functools.wraps(func)
     def timeit_wrapper(*args, **kwargs):
         start_time = time.perf_counter()

--- a/dicee/trainer/torch_trainer.py
+++ b/dicee/trainer/torch_trainer.py
@@ -4,6 +4,7 @@ from dicee.abstracts import AbstractTrainer
 import time
 import os
 from tqdm import tqdm
+import psutil
 
 class TorchTrainer(AbstractTrainer):
     """
@@ -30,11 +31,6 @@ class TorchTrainer(AbstractTrainer):
             self.device = torch.device(f'cuda:{self.attributes.gpus}' if torch.cuda.is_available() else 'cpu')
         else:
             self.device = 'cpu'
-        try:
-            import psutil
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("psutil is required for TorchTrainer but is part of the optional dependencies. "
-                                      "Please install it via 'pip install psutil'")
         # https://psutil.readthedocs.io/en/latest/#psutil.Process
         self.process = psutil.Process(os.getpid())
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ _core_deps = [
     "polars>=0.16.14",
     "pytorch_lightning>=2.5.1",
     "tiktoken>=0.5.1",
+    "psutil>=5.9.4",
 ]
 
 # Optional dependencies for various features
@@ -29,7 +30,6 @@ _optional_deps = [
     "rdflib>=7.0.0",
     "tiktoken>=0.5.1",
     "pykeen>=1.10.2",
-    "psutil>=5.9.4",
     "matplotlib>=3.8.2",
     "zstandard>=0.21.0",
     "requests>=2.32.3",


### PR DESCRIPTION
During a last check before making the release, I dealt with the issue below which is fixed in this PR.

Following this import from dicee package: `from .dataset_classes import *` > `from .static_funcs import timeit, load_term_mapping` we see that `timeit` is imported which is used as a [decorator](https://github.com/dice-group/dice-embeddings/blob/062db19d7139be77abe8db83eef038f6041f6cd3/dicee/dataset_classes.py#L11C2-L11C8) in `dataset_classes` module. On its end, `timeit` requires `psutils` which was a optional library but apparently we have to make this a core library because otherwise will be dealt with an import error if the user installs only the "min" dependencies.

