### PR TITLE
Fix for continual training with evaluation during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,15 @@ _:1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07
 <http://www.benchmark.org/family#hasParent> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
 ```
 
-**Continual Training:** the training phase of a pretrained model can be resumed. The model will saved in the same directory ``` --continual_learning "KeciFamilyRun"```.
+**Continual Training:** the training phase of a pretrained model can be resumed.
+The run reuses configuration and serialized artifacts from the existing experiment folder and stores updated outputs in the same directory using `--continual_learning "KeciFamilyRun"`.
 ```bash
 dicee --continual_learning "KeciFamilyRun" --path_single_kg "KGs/Family/family-benchmark_rich_background.owl" --model Keci --backend rdflib --eval_model None
 ```
+The continual directory should contain the stored configuration and serialized training data (for example `configuration.json`, `memory_map_train_set.npy`, and mapping files `entity_to_idx`/`relation_to_idx` in `.csv` or legacy `.p` format).
+If `--eval_model` is set, evaluation runs after training using stored indexed artifacts. If `--eval_model None`, no evaluation is executed.
+Periodic evaluation and weight-averaging callbacks are also supported in continual training.
+
 #### Ensemble Learning with Knowledge Graph Embeddings
 
 The KGE models in our **dice-embedding** framework now support a range of state-of-the-art weight averaging techniques, including:
@@ -1153,4 +1158,3 @@ url={https://openreview.net/forum?id=6T45-4TFqaX}}
   organization={IEEE}
 ```
 For any questions or wishes, please contact:  ```caglar.demir@upb.de```
-

--- a/dicee/evaluation/evaluator.py
+++ b/dicee/evaluation/evaluator.py
@@ -91,7 +91,7 @@ class Evaluator:
             self.re_vocab = dataset.re_vocab.result()
 
         if isinstance(dataset.ee_vocab, dict):
-            self.ee_vocab = dataset.ee_vocab.result()
+            self.ee_vocab = dataset.ee_vocab
         else:
             self.ee_vocab = dataset.ee_vocab.result()
 

--- a/dicee/executer.py
+++ b/dicee/executer.py
@@ -380,6 +380,7 @@ class ContinuousExecute(Execute):
         #
         previous_args["num_epochs"]=args["num_epochs"]
         previous_args["continual_learning"]=args["continual_learning"]
+        previous_args["path_experiment_folder"]=args["continual_learning"]
         print("Updated configuration:",previous_args)
         try:
             report = load_json(args['continual_learning'] + '/report.json')
@@ -409,21 +410,23 @@ class ContinuousExecute(Execute):
 
         """
         # (1)
+        self.evaluator = Evaluator(args=self.args, is_continual_training=True)
         self.trainer = DICE_Trainer(args=self.args,
                                     is_continual_training=True,
-                                    storage_path=self.args.continual_learning)
+                                    storage_path=self.args.continual_learning, evaluator=self.evaluator)
         # (2)
 
         assert os.path.exists(f"{self.args.continual_learning}/memory_map_train_set.npy")
         # (1) Reload the memory-map of index knowledge graph stored as a numpy ndarray.
-        with open(f"{self.args.continual_learning}/memory_map_details.json", 'r') as file_descriptor:
-            memory_map_details = json.load(file_descriptor)
-        knowledge_graph = np.memmap(f"{self.args.continual_learning}/memory_map_train_set.npy",
-                                         mode='r',
-                                         dtype=memory_map_details["dtype"],
-                                         shape=tuple(memory_map_details["shape"]))
-        self.args.num_entities = memory_map_details["num_entities"]
-        self.args.num_relations = memory_map_details["num_relations"]
+        # with open(f"{self.args.continual_learning}/memory_map_details.json", 'r') as file_descriptor:
+        #     memory_map_details = json.load(file_descriptor)
+        # knowledge_graph = np.memmap(f"{self.args.continual_learning}/memory_map_train_set.npy",
+        #                                  mode='r',
+        #                                  dtype=memory_map_details["dtype"],
+        #                                  shape=tuple(memory_map_details["shape"]))
+        knowledge_graph =  read_or_load_kg(self.args, cls=KG)
+        self.args.num_entities = knowledge_graph.num_entities
+        self.args.num_relations = knowledge_graph.num_relations
         self.args.num_tokens = None
         self.args.max_length_subword_tokens = None
         self.args.ordered_bpe_entities = None
@@ -435,6 +438,5 @@ class ContinuousExecute(Execute):
         if self.args.eval_model is None:
             return self.report
         else:
-            self.evaluator = Evaluator(args=self.args, is_continual_training=True)
             self.evaluator.dummy_eval(self.trained_model, form_of_labelling)
             return {**self.report, **self.evaluator.report}

--- a/dicee/read_preprocess_save_load_kg/save_load_disk.py
+++ b/dicee/read_preprocess_save_load_kg/save_load_disk.py
@@ -47,10 +47,19 @@ class LoadSaveToDisk:
         assert self.kg.path_for_deserialization is not None
         assert self.kg.path_for_serialization == self.kg.path_for_deserialization
 
-        self.kg.entity_to_idx = load_pickle(file_path=self.kg.path_for_deserialization + '/entity_to_idx.p')
-        self.kg.relation_to_idx = load_pickle(file_path=self.kg.path_for_deserialization + '/relation_to_idx.p')
-        assert isinstance(self.kg.entity_to_idx, dict)
-        assert isinstance(self.kg.relation_to_idx, dict)
+        # Backward compatible loading: prefer CSV, fallback to legacy pickle format.
+        if (os.path.isfile(self.kg.path_for_deserialization + '/entity_to_idx.csv') 
+            and os.path.isfile(self.kg.path_for_deserialization + '/relation_to_idx.csv')):
+            self.kg.entity_to_idx = pandas.read_csv(self.kg.path_for_deserialization + '/entity_to_idx.csv', index_col=0)
+            self.kg.relation_to_idx = pandas.read_csv(self.kg.path_for_deserialization + '/relation_to_idx.csv', index_col=0)
+        elif (os.path.isfile(self.kg.path_for_deserialization + '/entity_to_idx.p') 
+            and os.path.isfile(self.kg.path_for_deserialization + '/relation_to_idx.p')):
+            self.kg.entity_to_idx = load_pickle(file_path=self.kg.path_for_deserialization + '/entity_to_idx.p')
+            self.kg.relation_to_idx = load_pickle(file_path=self.kg.path_for_deserialization + '/relation_to_idx.p')
+        else:
+            raise FileNotFoundError(f"Could not find mapping files in {self.kg.path_for_deserialization}. "
+                "Expected entity_to_idx/relation_to_idx as either .csv or .p")
+        
         self.kg.num_entities = len(self.kg.entity_to_idx)
         self.kg.num_relations = len(self.kg.relation_to_idx)
 
@@ -65,5 +74,8 @@ class LoadSaveToDisk:
             self.kg.er_vocab = load_pickle(file_path=self.kg.path_for_deserialization + '/er_vocab.p')
             self.kg.re_vocab = load_pickle(file_path=self.kg.path_for_deserialization + '/re_vocab.p')
             self.kg.ee_vocab = load_pickle(file_path=self.kg.path_for_deserialization + '/ee_vocab.p')
-            self.kg.domain_constraints_per_rel, self.kg.range_constraints_per_rel = load_pickle(
-                file_path=self.kg.path_for_deserialization + '/constraints.p')
+            constraints_path = self.kg.path_for_deserialization + '/constraints.p'
+            if os.path.isfile(constraints_path):
+                self.kg.domain_constraints_per_rel, self.kg.range_constraints_per_rel = load_pickle(
+                    file_path=constraints_path
+                )

--- a/tests/test_regression_cl.py
+++ b/tests/test_regression_cl.py
@@ -1,6 +1,8 @@
 from dicee.executer import Execute, ContinuousExecute
 import pytest
 from dicee.config import Namespace
+import os
+import json
 class TestRegressionAConEx:
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_k_vs_all(self):
@@ -32,3 +34,74 @@ class TestRegressionAConEx:
         assert cl_result['Train']['H@10'] >= result['Train']['H@10']
         assert cl_result['Val']['H@10'] >= result['Val']['H@10']
         assert cl_result['Test']['H@10'] >= result['Test']['H@10']
+
+    @pytest.mark.filterwarnings('ignore::UserWarning')
+    def test_continual_with_periodic_eval(self):
+        args = Namespace()
+        args.model = 'Keci'
+        args.p = 0
+        args.q = 1
+        args.scoring_technique = "KvsAll"
+        args.optim = 'Adam'
+        args.dataset_dir = "KGs/UMLS"
+        args.backend = "pandas"
+        args.num_epochs = 10
+        args.batch_size = 1024
+        args.lr = 0.1
+        args.embedding_dim = 32
+        args.eval_model = 'train_val_test'
+        args.eval_every_n_epochs = 1
+        args.trainer = 'torchCPUTrainer'
+        initial_result = Execute(args).start()
+
+        periodic_eval_path = initial_result['path_experiment_folder'] + '/eval_report_n_epochs.json'
+        assert os.path.isfile(periodic_eval_path)
+        with open(periodic_eval_path, 'r') as f:
+            initial_periodic = json.load(f)
+        assert isinstance(initial_periodic, dict)
+        initial_mtime = os.path.getmtime(periodic_eval_path)
+
+        args.continual_learning = initial_result['path_experiment_folder']
+        continual_result = ContinuousExecute(args).continual_start()
+
+        assert 'Train' in continual_result
+        assert 'Val' in continual_result
+        assert 'Test' in continual_result
+        assert os.path.isfile(periodic_eval_path)
+        with open(periodic_eval_path, 'r') as f:
+            continual_periodic = json.load(f)
+        assert isinstance(continual_periodic, dict)
+        assert len(continual_periodic) > 0
+        assert os.path.getmtime(periodic_eval_path) >= initial_mtime
+
+    @pytest.mark.filterwarnings('ignore::UserWarning')
+    def test_continual_with_adaptive_swa(self):
+        args = Namespace()
+        args.model = 'Keci'
+        args.p = 0
+        args.q = 1
+        args.scoring_technique = "KvsAll"
+        args.optim = 'Adam'
+        args.dataset_dir = "KGs/UMLS"
+        args.backend = "pandas"
+        args.num_epochs = 10
+        args.batch_size = 1024
+        args.lr = 0.1
+        args.embedding_dim = 32
+        args.eval_model = 'train_val_test'
+        args.adaptive_swa = True
+        args.trainer = 'torchCPUTrainer'
+        initial_result = Execute(args).start()
+
+        aswa_path = initial_result['path_experiment_folder'] + '/aswa.pt'
+        assert os.path.isfile(aswa_path)
+        initial_mtime = os.path.getmtime(aswa_path)
+
+        args.continual_learning = initial_result['path_experiment_folder']
+        continual_result = ContinuousExecute(args).continual_start()
+
+        assert 'Train' in continual_result
+        assert 'Val' in continual_result
+        assert 'Test' in continual_result
+        assert os.path.isfile(aswa_path)
+        assert os.path.getmtime(aswa_path) >= initial_mtime


### PR DESCRIPTION
## Summary

This PR fixes continual-learning with periodic evaluation, ASWA and adds regression coverage to prevent recurrence.

## What Changed

- Updated continual execution flow to reuse experiment context correctly.
  - Persist `path_experiment_folder` into `previous_args`.
  - Initialize and pass a single `Evaluator` instance consistently in continual training.
  - Load KG via `read_or_load_kg(...)` instead of direct memmap file assumptions.
  - Load KG via `LoadSaveToDisk(kg=self).load()` instead of recreating KG from scratch in continual training.
  - Set `num_entities` / `num_relations` from loaded KG object.

- Fixed evaluator behavior [Minor Bug Fix]
  - Use `dataset.ee_vocab` directly (no `.result()` call).

- Made deserialization backward-compatible in disk loading.
  - Prefer `entity_to_idx.csv` / `relation_to_idx.csv` when present.
  - Fallback to legacy pickle files (`.p`) if CSVs are absent.
  - Raise clear `FileNotFoundError` if neither format exists.
  - Load `constraints.p` only when present (optional constraints handling).

- Added regression tests for continual learning.
  - `test_continual_with_periodic_eval`
  - `test_continual_with_adaptive_swa`


## Files Changed

- `dicee/executer.py`
- `dicee/evaluation/evaluator.py`
- `dicee/read_preprocess_save_load_kg/save_load_disk.py`
- `tests/test_regression_cl.py`
