### PR TITLE
CoKE regression fix

### DIFF
--- a/tests/test_regression_coke.py
+++ b/tests/test_regression_coke.py
@@ -1,6 +1,12 @@
 from dicee.executer import Execute
 import pytest
 from dicee.config import Namespace
+import os
+import torch
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["OMP_NUM_THREADS"] = "1"
+torch.set_num_threads(1)
+torch.set_num_interop_threads(1)
 
 class TestRegressionCoKE:
     @pytest.mark.filterwarnings('ignore::UserWarning')
@@ -100,4 +106,3 @@ class TestRegressionCoKE:
         assert 0.45 >= result['Train']['H@1'] >= 0.25
         assert 0.45 >= result['Test']['H@1'] >= 0.25
         assert 0.45 >= result['Val']['H@1'] >= 0.25
-

--- a/tests/test_regression_coke.py
+++ b/tests/test_regression_coke.py
@@ -1,12 +1,16 @@
 from dicee.executer import Execute
 import pytest
 from dicee.config import Namespace
+
 import os
 import torch
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
 torch.set_num_threads(1)
 torch.set_num_interop_threads(1)
+# AllvsAll tests fail with "MKL_NUM_THREADS" = 2 ( or some other values) 
+# due to numerical drift in multi-threaded CPU execution.
+# Setting to 1 stabilizes the runs and ensures consistent metrics.
 
 class TestRegressionCoKE:
     @pytest.mark.filterwarnings('ignore::UserWarning')


### PR DESCRIPTION
This PR sets manual thread counts as a fix for `CoKE -AllvsAll` regression test fails (random occurrence).
For the CoKE regression script, thread limits are now set at script level to prevent the same instability across tests, which was  seen in `test_all_vs_all`  for extra safety. No regression bounds or model settings were changed.