### PR TITLE
minor fixes relating to python v >= 3.11

### DIFF
--- a/dicee/query_generator.py
+++ b/dicee/query_generator.py
@@ -112,7 +112,7 @@ class QueryGenerator:
                 for j in range(40):
                     if len(ent_in[answer].keys()) < 1:
                         return True  # not enough relations, return True to indicate broken flag
-                    r_tmp = random.sample(ent_in[answer].keys(), 1)[0]
+                    r_tmp = random.sample(list(ent_in[answer].keys()), 1)[0]
                     if r_tmp // 2 != r // 2 or r_tmp == r:
                         r = r_tmp
                         found = True
@@ -120,7 +120,7 @@ class QueryGenerator:
                 if not found:
                     return True
                 query_structure[-1][i] = r
-                answer = random.sample(ent_in[answer][r], 1)[0]
+                answer = random.sample(list(ent_in[answer][r]), 1)[0]
             if query_structure[0] == 'e':
                 query_structure[0] = answer
             else:

--- a/dicee/scripts/run.py
+++ b/dicee/scripts/run.py
@@ -27,7 +27,7 @@ def get_default_arguments(description=None):
     parser.add_argument("--backend", type=str, default="pandas",
                         choices=["pandas", "polars", "rdflib"],
                         help='Backend for loading, preprocessing, indexing input knowledge graph.')
-    parser.add_argument("--separator", type=str, default="\s+",
+    parser.add_argument("--separator", type=str, default="\\s+",
                         help='Pandas \s+, t for \t polars works with the last two.')
     parser.add_argument("--reuse_existing_run_dir", action="store_true",
                         help="If set, reuse the existing path_to_store_single_run directory if it exists. "
@@ -110,7 +110,7 @@ def get_default_arguments(description=None):
     parser.add_argument("--read_only_few", type=int, default=None,
                         help='READ only first N triples. If 0, read all.')
     parser.add_argument("--add_noise_rate", type=float, default=0.0,
-                        help='Add x % of noisy triples into training dataset.')
+                        help='Add x%% of noisy triples into training dataset.')
     # WIP
 
     parser.add_argument('--r', type=int, default=0,

--- a/dicee/scripts/run.py
+++ b/dicee/scripts/run.py
@@ -110,7 +110,7 @@ def get_default_arguments(description=None):
     parser.add_argument("--read_only_few", type=int, default=None,
                         help='READ only first N triples. If 0, read all.')
     parser.add_argument("--add_noise_rate", type=float, default=0.0,
-                        help='Add x%% of noisy triples into training dataset.')
+                        help='Add x% of noisy triples into training dataset.')
     # WIP
 
     parser.add_argument('--r', type=int, default=0,

--- a/dicee/scripts/run.py
+++ b/dicee/scripts/run.py
@@ -27,7 +27,7 @@ def get_default_arguments(description=None):
     parser.add_argument("--backend", type=str, default="pandas",
                         choices=["pandas", "polars", "rdflib"],
                         help='Backend for loading, preprocessing, indexing input knowledge graph.')
-    parser.add_argument("--separator", type=str, default="\\s+",
+    parser.add_argument("--separator", type=str, default="\s+",
                         help='Pandas \s+, t for \t polars works with the last two.')
     parser.add_argument("--reuse_existing_run_dir", action="store_true",
                         help="If set, reuse the existing path_to_store_single_run directory if it exists. "

--- a/dicee/scripts/run.py
+++ b/dicee/scripts/run.py
@@ -110,7 +110,7 @@ def get_default_arguments(description=None):
     parser.add_argument("--read_only_few", type=int, default=None,
                         help='READ only first N triples. If 0, read all.')
     parser.add_argument("--add_noise_rate", type=float, default=0.0,
-                        help='Add x% of noisy triples into training dataset.')
+                        help='Add x % of noisy triples into training dataset.')
     # WIP
 
     parser.add_argument('--r', type=int, default=0,


### PR DESCRIPTION
This commit applies Python 3.11 (or greater) compatibility fixes in [query_generator.py](https://github.com/dice-group/dice-embeddings/blob/develop/dicee/query_generator.py) and [run.py](https://github.com/dice-group/dice-embeddings/blob/develop/dicee/scripts/run.py). It wraps `random.sample(...)` inputs with `list(...)` so sampling works with dict/set views, and corrects argparse/help-string escaping ("\\s+" and x%%) to avoid parsing/formatting issues.