### PR TITLE
Multinode fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ A KGE model model can also be trained in multi-node multi-gpu DDP setting.
 torchrun --nnodes 2 --nproc_per_node=gpu  --node_rank 0 --rdzv_id 455 --rdzv_backend c10d --rdzv_endpoint=nebula  dicee --trainer "torchDDP" --dataset_dir "KGs/YAGO3-10" --path_to_store_single_run "YAGO3_torchDDP"
 torchrun --nnodes 2 --nproc_per_node=gpu  --node_rank 1 --rdzv_id 455 --rdzv_backend c10d --rdzv_endpoint=nebula  dicee --trainer "torchDDP" --dataset_dir "KGs/YAGO3-10" --path_to_store_single_run "YAGO3_torchDDP"
 ```
+Multi-node training is also possible with the `PL` trainer 
+```bash
+torchrun --nnodes 2 --nproc_per_node=gpu  --node_rank 0 --rdzv_id 455 --rdzv_backend c10d --rdzv_endpoint=nebula  dicee --trainer "PL" --dataset_dir "KGs/YAGO3-10" --path_to_store_single_run "YAGO3_PL"
+torchrun --nnodes 2 --nproc_per_node=gpu  --node_rank 1 --rdzv_id 455 --rdzv_backend c10d --rdzv_endpoint=nebula  dicee --trainer "PL" --dataset_dir "KGs/YAGO3-10" --path_to_store_single_run "YAGO3_PL"
+```
+
 On large knowledge graphs, this configurations should be used.
 Note: When training with multi-GPU or Distributed Data Parallel (DDP) settings, you must provide the `--path_to_store_single_run` argument to specify where to store the results of a single training run. This ensures that all processes write to the correct directory and prevents conflicts.
 
@@ -120,6 +126,7 @@ CUDA_VISIBLE_DEVICES=0 dicee --dataset_dir "KGs/UMLS" --trainer "PL" --scoring_t
 ``` 
 The `CUDA_VISIBLE_DEVICES=0` setting limits the program to access only the specified GPU(s), making all others invisible.  
 Multiple GPUs can be selected by providing a comma-separated list, for example: `CUDA_VISIBLE_DEVICES=0,1`.
+Additional PyTorch Lightning trainer options can be passed with `--pl_trainer_kwargs`, e.g. `--pl_trainer_kwargs '{"precision":"16-mixed","strategy":"ddp"}'`. PyTorch Lightning Trainer has many optional parameters; see: https://lightning.ai/docs/pytorch/stable/common/trainer.html
 
 
 The data is in the following form

--- a/dicee/callbacks.py
+++ b/dicee/callbacks.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 import numpy as np
 import pandas as pd
 import torch
-from pytorch_lightning.utilities import rank_zero_only
+from lightning.pytorch.utilities import rank_zero_only
 from torch._dynamo.eval_frame import OptimizedModule
 from torch.optim.lr_scheduler import LambdaLR
 

--- a/dicee/config.py
+++ b/dicee/config.py
@@ -113,6 +113,9 @@ class Namespace(argparse.Namespace):
         self.pykeen_model_kwargs = dict()
         """Additional keyword arguments for pykeen models"""
 
+        self.pl_trainer_kwargs = dict()
+        """Additional keyword arguments for the PyTorch Lightning Trainer"""
+
         # Below attributes can be given as model_kwargs argument
 
         self.kernel_size: int = 3

--- a/dicee/executer.py
+++ b/dicee/executer.py
@@ -14,7 +14,6 @@ from types import SimpleNamespace
 from typing import Dict, Optional
 
 import numpy as np
-import torch
 import torch.distributed as dist
 from pytorch_lightning import seed_everything
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
@@ -327,30 +326,33 @@ class Execute:
         A dict containing information about the training and/or evaluation
 
         """
-        self.start_time = time.time()
-        print(f"Start time:{datetime.datetime.now()}")
-        # (1) Create knowledge graph
-        self.create_and_store_kg()
-        # (2) Synchronize processes if distributed training is used
-        if self.distributed and dist.is_initialized():
-            dist.barrier()
+        try:
+            self.start_time = time.time()
+            print(f"Start time:{datetime.datetime.now()}")
+            # (1) Create knowledge graph
+            self.create_and_store_kg()
+            # (2) Synchronize processes if distributed training is used
+            if self.distributed and dist.is_initialized():
+                dist.barrier()
 
-        # (3) Reload the memory-map of index knowledge graph stored as a numpy ndarray
-        if self.knowledge_graph is None:
-            self.load_from_memmap()
+            # (3) Reload the memory-map of index knowledge graph stored as a numpy ndarray
+            if self.knowledge_graph is None:
+                self.load_from_memmap()
 
-        # (4) Create an evaluator object.
-        self.evaluator = Evaluator(args=self.args)
-        # (5) Create a trainer object.
-        if not getattr(self.args, "full_storage_path", None):
-            self.args.full_storage_path = self.args.path_to_store_single_run
-        self.trainer = DICE_Trainer(args=self.args,
-                                    is_continual_training=self.is_continual_training,
-                                    storage_path=self.args.full_storage_path,
-                                    evaluator=self.evaluator)
-        # (6) Start the training
-        self.trained_model, form_of_labelling = self.trainer.start(knowledge_graph=self.knowledge_graph)
-        return self.end(form_of_labelling)
+            # (4) Create an evaluator object.
+            self.evaluator = Evaluator(args=self.args)
+            # (5) Create a trainer object.
+            if not getattr(self.args, "full_storage_path", None):
+                self.args.full_storage_path = self.args.path_to_store_single_run
+            self.trainer = DICE_Trainer(args=self.args,
+                                        is_continual_training=self.is_continual_training,
+                                        storage_path=self.args.full_storage_path,
+                                        evaluator=self.evaluator)
+            # (6) Start the training
+            self.trained_model, form_of_labelling = self.trainer.start(knowledge_graph=self.knowledge_graph)
+            return self.end(form_of_labelling)
+        finally:
+            self.cleanup()
 
 
 class ContinuousExecute(Execute):

--- a/dicee/executer.py
+++ b/dicee/executer.py
@@ -15,8 +15,8 @@ from typing import Dict, Optional
 
 import numpy as np
 import torch.distributed as dist
-from pytorch_lightning import seed_everything
-from pytorch_lightning.utilities.rank_zero import rank_zero_only
+from lightning import seed_everything
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 
 from .evaluator import Evaluator
 from .knowledge_graph import KG
@@ -32,7 +32,7 @@ from .static_preprocess_funcs import preprocesses_input_args
 from .trainer import DICE_Trainer
 
 # Configure logging
-logging.getLogger('pytorch_lightning').setLevel(logging.WARNING)
+logging.getLogger('lightning').setLevel(logging.WARNING)
 warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 os.environ["TORCH_DISTRIBUTED_DEBUG"] = "INFO"
 

--- a/dicee/executer.py
+++ b/dicee/executer.py
@@ -25,6 +25,7 @@ from .static_funcs import (
     create_experiment_folder,
     load_json,
     read_or_load_kg,
+    setup_distributed_training,
     store,
     timeit,
 )
@@ -64,10 +65,16 @@ class Execute:
             args: Configuration arguments (Namespace or similar).
             continuous_training: Whether this is continual training.
         """
-        # Check if we need distributed training
-        self.distributed = getattr(args, "trainer", None) == "torchDDP"
-        # Initialize distributed training if required
-        self._setup_distributed_training(args)
+        # Setup distributed and device ranks before training
+        distributed_setup = setup_distributed_training(args)
+        # Checks if the current training setup is distributed
+        self.distributed = distributed_setup["distributed"]
+        # Rank of the current process/GPU globally
+        self.rank = distributed_setup["rank"]
+        # Total number of nodes in the training
+        self.world_size = distributed_setup["world_size"]
+        # Rank of the current process/GPU within the node
+        self.local_rank = distributed_setup["local_rank"]
         # (1) Process arguments and sanity checking
         self.args = preprocesses_input_args(args)
         # (2) Ensure reproducibility
@@ -88,27 +95,6 @@ class Execute:
         self.evaluator: Optional[Evaluator] = None
         # (9) Execution start time
         self.start_time: Optional[float] = None
-
-    def _setup_distributed_training(self, args) -> None:
-        """Set up distributed training environment if enabled."""
-        if self.distributed:
-            self.local_rank = int(os.environ["LOCAL_RANK"])
-            torch.cuda.set_device(self.local_rank)
-            assert torch.cuda.current_device() == self.local_rank, \
-                f"set_device failed! local_rank={self.local_rank} but current={torch.cuda.current_device()}"
-            if not dist.is_initialized():
-                dist.init_process_group(backend="nccl", init_method="env://",
-                                         device_id=torch.device(f"cuda:{self.local_rank}"))
-            self.rank = dist.get_rank()
-            self.world_size = dist.get_world_size()
-            print(f"[Rank {self.rank}] mapped to GPU {self.local_rank}", flush=True)
-        
-        elif args.trainer == "PL":
-            self.local_rank = int(os.environ.get("LOCAL_RANK", getattr(rank_zero_only, "rank", 0)))
-            self.rank = int(os.environ.get("RANK", self.local_rank))
-            self.world_size = int(os.environ.get("WORLD_SIZE", torch.cuda.device_count()))
-        else:
-            self.rank, self.world_size, self.local_rank = 0, 1, 0
 
     def is_local_rank_zero(self) -> bool:
         return self.local_rank == 0

--- a/dicee/scripts/run.py
+++ b/dicee/scripts/run.py
@@ -92,6 +92,10 @@ def get_default_arguments(description=None):
     parser.add_argument('--q', type=int, default=1,
                         help='Q for Clifford Algebra')
     parser.add_argument('--pykeen_model_kwargs', type=json.loads, default={})
+    parser.add_argument("--pl_trainer_kwargs",type=json.loads, default={},
+        help='Additional PyTorch Lightning Trainer keyword arguments as JSON. '
+             'Example: {"accelerator": "gpu", "strategy": "ddp", "precision": "16-mixed"}'
+    )
 
     # Evaluation Related
     parser.add_argument('--num_folds_for_cv', type=int, default=0,

--- a/dicee/scripts/run.py
+++ b/dicee/scripts/run.py
@@ -3,7 +3,7 @@ from dicee.executer import Execute, ContinuousExecute
 import argparse
 
 def get_default_arguments(description=None):
-    """ Extends pytorch_lightning Trainer's arguments with ours """
+    """ Extends lightning Trainer's arguments with ours """
     parser = argparse.ArgumentParser(add_help=False)
     # Default Trainer param https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#methods
     # Knowledge graph related arguments

--- a/dicee/static_funcs.py
+++ b/dicee/static_funcs.py
@@ -20,7 +20,7 @@ import polars as pl
 import requests
 import torch
 import torch.distributed as dist
-from pytorch_lightning.utilities.rank_zero import rank_zero_only
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 
 from .models import (
     AConEx, AConvO, AConvQ, CKeci, CoKE, ComplEx, ConEx, ConvO, ConvQ,

--- a/dicee/static_funcs.py
+++ b/dicee/static_funcs.py
@@ -19,6 +19,8 @@ import pandas as pd
 import polars as pl
 import requests
 import torch
+import torch.distributed as dist
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 from .models import (
     AConEx, AConvO, AConvQ, CKeci, CoKE, ComplEx, ConEx, ConvO, ConvQ,
@@ -145,6 +147,53 @@ def timeit(func: Callable) -> Callable:
         print(f'Took {total_time:.4f} secs | Current Memory Usage {memory_mb:.5f} MB')
         return result
     return timeit_wrapper
+
+
+def setup_distributed_training(args) -> Dict[str, Union[bool, int]]:
+    """Resolve distributed-training state and initialize custom DDP when needed."""
+    trainer_name = getattr(args, "trainer", None)
+    required_env_vars = ("LOCAL_RANK", "RANK", "WORLD_SIZE")
+    torchrun_launched = all(env_var in os.environ for env_var in required_env_vars)
+    distributed = trainer_name == "torchDDP" or (
+        trainer_name == "PL" and torchrun_launched
+    )
+
+    if trainer_name == "torchDDP" and not torchrun_launched:
+        raise RuntimeError(
+            "torchDDP trainer must be launched with torchrun."
+            "Please use appropriate commands for torchDDP trainer."
+        )
+
+    if distributed or trainer_name == "PL":
+        local_rank = int(os.environ.get("LOCAL_RANK", getattr(rank_zero_only, "rank", 0)))
+        rank = int(os.environ.get("RANK", local_rank))
+        world_size = int(os.environ.get("WORLD_SIZE", torch.cuda.device_count()))
+
+        if distributed:
+            torch.cuda.set_device(local_rank)
+            assert torch.cuda.current_device() == local_rank, (
+                f"set_device failed! local_rank={local_rank} "
+                f"but current={torch.cuda.current_device()}"
+            )
+            if not dist.is_initialized():
+                dist.init_process_group(
+                    backend="nccl",
+                    init_method="env://",
+                    device_id=torch.device(f"cuda:{local_rank}"),
+                )
+            rank = dist.get_rank()
+            world_size = dist.get_world_size()
+            print(f"[Rank {rank}] mapped to GPU {local_rank}", flush=True)
+    else:
+        distributed = False
+        rank, world_size, local_rank = 0, 1, 0
+
+    return {
+        "distributed": distributed,
+        "rank": rank,
+        "world_size": world_size,
+        "local_rank": local_rank,
+    }
 
 def save_pickle(*, data: Optional[object] = None, file_path: str) -> None:
     """Save data to a pickle file.

--- a/dicee/trainer/dice_trainer.py
+++ b/dicee/trainer/dice_trainer.py
@@ -74,7 +74,7 @@ def initialize_trainer(
         trainer = TorchDDPTrainer(args, callbacks=callbacks)
     elif args.trainer == 'PL':
         print('Initializing Pytorch-lightning Trainer', end='\t')
-        kwargs = vars(args)
+        kwargs = {**vars(args), **(getattr(args, "pl_trainer_kwargs", {}) or {})}
         # NOTE: PyTorch Lightning Trainer has many optional parameters
         # See: https://lightning.ai/docs/pytorch/stable/common/trainer.html
         trainer = pl.Trainer(accelerator=kwargs.get("accelerator", "auto"),

--- a/dicee/trainer/dice_trainer.py
+++ b/dicee/trainer/dice_trainer.py
@@ -233,7 +233,7 @@ class DICE_Trainer:
         """
 
         self.trainer = self.initialize_trainer(callbacks=get_callbacks(self.args))
-        model, form_of_labelling = self._initialize_model_for_current_trainer()
+        model, form_of_labelling = self.initialize_or_load_model()
         # TODO: Here we need to load memory pag
         self.trainer.evaluator = self.evaluator
         self.trainer.dataset = knowledge_graph
@@ -253,27 +253,6 @@ class DICE_Trainer:
         self.report['form_of_labelling'] = form_of_labelling
         assert form_of_labelling in ['EntityPrediction', 'RelationPrediction']
         return model, form_of_labelling
-
-    def _initialize_model_for_current_trainer(self):
-        """Initialize the model with FSDP-aware empty init only for Lightning FSDP."""
-        pl_kwargs = getattr(self.args, "pl_trainer_kwargs", {}) or {}
-        strategy = pl_kwargs.get("strategy", "auto")
-
-        if isinstance(self.trainer, pl.Trainer) and strategy == "fsdp":
-            with self.trainer.init_module(empty_init=True):
-                model, form_of_labelling = self.initialize_or_load_model()
-            first_parameter = next(model.parameters())
-            allocated_mb = torch.cuda.memory_allocated() / (1024 ** 2) if torch.cuda.is_available() else 0.0
-            print(
-                "Temporary FSDP init verification:",
-                f"device={first_parameter.device}",
-                f"is_meta={first_parameter.is_meta}",
-                f"cuda_memory_allocated_mb={allocated_mb:.2f}",
-                flush=True,
-            )
-            return model, form_of_labelling
-
-        return self.initialize_or_load_model()
 
     @timeit
     def init_dataloader(self, dataset: torch.utils.data.Dataset) -> torch.utils.data.DataLoader:
@@ -359,7 +338,7 @@ class DICE_Trainer:
         if self.args.num_folds_for_cv == 0:
             self.trainer: Union[TensorParallel, TorchTrainer, TorchDDPTrainer, pl.Trainer]
             self.trainer = self.initialize_trainer(callbacks=get_callbacks(self.args))
-            model, form_of_labelling = self._initialize_model_for_current_trainer()
+            model, form_of_labelling = self.initialize_or_load_model()
             self.trainer.evaluator = self.evaluator
             self.trainer.dataset = knowledge_graph
             self.trainer.form_of_labelling = form_of_labelling

--- a/dicee/trainer/dice_trainer.py
+++ b/dicee/trainer/dice_trainer.py
@@ -233,7 +233,7 @@ class DICE_Trainer:
         """
 
         self.trainer = self.initialize_trainer(callbacks=get_callbacks(self.args))
-        model, form_of_labelling = self.initialize_or_load_model()
+        model, form_of_labelling = self._initialize_model_for_current_trainer()
         # TODO: Here we need to load memory pag
         self.trainer.evaluator = self.evaluator
         self.trainer.dataset = knowledge_graph
@@ -253,6 +253,27 @@ class DICE_Trainer:
         self.report['form_of_labelling'] = form_of_labelling
         assert form_of_labelling in ['EntityPrediction', 'RelationPrediction']
         return model, form_of_labelling
+
+    def _initialize_model_for_current_trainer(self):
+        """Initialize the model with FSDP-aware empty init only for Lightning FSDP."""
+        pl_kwargs = getattr(self.args, "pl_trainer_kwargs", {}) or {}
+        strategy = pl_kwargs.get("strategy", "auto")
+
+        if isinstance(self.trainer, pl.Trainer) and strategy == "fsdp":
+            with self.trainer.init_module(empty_init=True):
+                model, form_of_labelling = self.initialize_or_load_model()
+            first_parameter = next(model.parameters())
+            allocated_mb = torch.cuda.memory_allocated() / (1024 ** 2) if torch.cuda.is_available() else 0.0
+            print(
+                "Temporary FSDP init verification:",
+                f"device={first_parameter.device}",
+                f"is_meta={first_parameter.is_meta}",
+                f"cuda_memory_allocated_mb={allocated_mb:.2f}",
+                flush=True,
+            )
+            return model, form_of_labelling
+
+        return self.initialize_or_load_model()
 
     @timeit
     def init_dataloader(self, dataset: torch.utils.data.Dataset) -> torch.utils.data.DataLoader:
@@ -338,7 +359,7 @@ class DICE_Trainer:
         if self.args.num_folds_for_cv == 0:
             self.trainer: Union[TensorParallel, TorchTrainer, TorchDDPTrainer, pl.Trainer]
             self.trainer = self.initialize_trainer(callbacks=get_callbacks(self.args))
-            model, form_of_labelling = self.initialize_or_load_model()
+            model, form_of_labelling = self._initialize_model_for_current_trainer()
             self.trainer.evaluator = self.evaluator
             self.trainer.dataset = knowledge_graph
             self.trainer.form_of_labelling = form_of_labelling

--- a/dicee/weight_averaging.py
+++ b/dicee/weight_averaging.py
@@ -4,7 +4,7 @@ import json
 import torch
 import torch.nn as nn
 from torch._dynamo.eval_frame import OptimizedModule
-from pytorch_lightning.utilities import rank_zero_only
+from  lightning.pytorch.utilities import rank_zero_only
 
 from .abstracts import AbstractCallback
 from dicee.models.ensemble import EnsembleKGE

--- a/examples/run_pykeen.py
+++ b/examples/run_pykeen.py
@@ -6,7 +6,7 @@ import time
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop
 from pykeen.evaluation import RankBasedEvaluator
 
-import pytorch_lightning as pl
+import lightning as pl
 import argparse
 import warnings
 
@@ -15,7 +15,7 @@ warnings.filterwarnings(action="ignore", category=UserWarning)
 
 
 def get_default_arguments():
-    """ Extends pytorch_lightning Trainer's arguments with ours """
+    """ Extends lightning Trainer's arguments with ours """
     parser = pl.Trainer.add_argparse_args(argparse.ArgumentParser(add_help=False))
     parser.add_argument("--dataset", type=str, default='UMLS')
     parser.add_argument("--model", type=str,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ _core_deps = [
     "pandas<=2.3.3",
     "requests>=2.32.3",
     "polars>=0.16.14",
-    "pytorch_lightning>=2.5.1",
     "tiktoken>=0.5.1",
     "psutil>=5.9.4",
 ]


### PR DESCRIPTION
This pull request primarily improves multi-node and distributed training support, especially for the `PL` trainer, while also aligning the codebase with the newer `lightning` package API. The main functional changes are exposing PyTorch Lightning trainer kwargs through the CLI/config, tightening distributed setup and rank handling during execution, and documenting the new multi-node `PL` workflow in the README.

- Added `--pl_trainer_kwargs` support in `dicee/scripts/run.py` and `dicee/config.py`, so extra Lightning `Trainer` options can be passed through the CLI.
- Updated `dicee/trainer/dice_trainer.py` to merge `pl_trainer_kwargs` into the `PL` trainer initialization, enabling options like `strategy`, `precision`, `accelerator`, and `num_nodes`.
- Refactored distributed setup in `dicee/executer.py` and moved a function into `dicee/static_funcs.py` to centralize rank/world-size detection, support `torchrun`-launched `PL` jobs, and ensure setup/cleanup behave correctly in distributed runs.
- Changed executor behavior to perform run-directory and KG memmap creation on local rank 0, reducing conflicts in multi-process and multi-node execution.
- Migrated remaining imports/usages from `pytorch_lightning` to `lightning` in `dicee/executer.py`, `dicee/callbacks.py`, `dicee/weight_averaging.py`, and `examples/run_pykeen.py`.
- Removed the redundant `pytorch_lightning` dependency from `setup.py`, since `lightning` is already used.

