### PR TITLE
Decouple auto batch finding from TensorParallel and extend to all tra…

### DIFF
--- a/dicee/trainer/auto_batch_finder.py
+++ b/dicee/trainer/auto_batch_finder.py
@@ -1,0 +1,117 @@
+import time
+from typing import Callable, Optional, Tuple
+
+import torch
+
+
+def find_good_batch_size(
+    train_loader: torch.utils.data.DataLoader,
+    training_step_fn: Callable,
+    device,
+) -> Tuple[int, Optional[float]]:
+    """Find a batch size that uses GPU memory efficiently.
+
+    Progressively increases batch size (with tunable delta) until GPU memory
+    exceeds 90% or a CUDA OOM error is raised, then backs off to the last safe
+    batch size.  Only supported on CUDA devices; returns the initial batch size
+    unchanged on CPU.
+
+    Args:
+        train_loader: DataLoader wrapping the training dataset.
+        training_step_fn: Callable[[batch], float] — runs one forward+backward
+            pass and returns the scalar loss.  Each trainer passes its own
+            implementation so this function stays trainer-agnostic.
+        device: torch.device (or anything accepted by torch.device()) used to
+            monitor GPU memory.
+
+    Returns:
+        (batch_size, runtime) where runtime is the wall-clock seconds of the
+        last successful batch, or None when batch finding was skipped.
+    """
+    initial_batch_size = train_loader.batch_size
+    training_dataset_size = len(train_loader.dataset)
+
+    if initial_batch_size >= training_dataset_size:
+        return training_dataset_size, None
+
+    # Normalise device
+    if not isinstance(device, torch.device):
+        device = torch.device(device)
+
+    if device.type != "cuda":
+        print("Auto batch finding requires a CUDA device — skipping.")
+        return initial_batch_size, None
+
+    print(f"Auto batch finding — training data points: {training_dataset_size}")
+
+    def _try_increasing(batch_size: int, delta: int):
+        """Increase batch_size until OOM or >90 % GPU memory, return history."""
+        history = []
+        try:
+            while True:
+                start = time.time()
+                loader = torch.utils.data.DataLoader(
+                    train_loader.dataset,
+                    batch_size=batch_size,
+                    shuffle=True,
+                    num_workers=train_loader.num_workers,
+                    collate_fn=train_loader.dataset.collate_fn,
+                    pin_memory=False,
+                    drop_last=False,
+                    persistent_workers=False,
+                )
+                batch_loss = None
+                for batch in loader:
+                    batch_loss = training_step_fn(batch)
+                    break
+
+                free, total = torch.cuda.mem_get_info(device=device)
+                pct_used = (total - free) / total
+                rt = time.time() - start
+
+                print(
+                    f"Batch Loss: {batch_loss:.4f}\t"
+                    f"GPU Usage: {pct_used:.3f}\t"
+                    f"Runtime: {rt:.3f}s\t"
+                    f"Batch Size: {batch_size}"
+                )
+                history.append((batch_size, rt))
+
+                # Stay below 90 % to avoid the illegal-memory-access bug:
+                # https://github.com/pytorch/pytorch/issues/21819
+                if pct_used > 0.9:
+                    return history, False
+                if batch_size < training_dataset_size:
+                    batch_size += int(batch_size / delta)
+                else:
+                    return history, True
+
+        except torch.OutOfMemoryError:
+            gpu_mem = torch.cuda.get_device_properties(device).total_memory / (1024 ** 3)
+            allocated = torch.cuda.memory_allocated(device) / (1024 ** 3)
+            print(
+                f"CUDA OOM at batch_size={batch_size} "
+                f"({gpu_mem:.2f} GB total, {allocated:.2f} GB allocated)"
+            )
+            return history, False
+
+    full_history = []
+    batch_size = initial_batch_size
+    batch_rt = None
+
+    for delta in range(1, 5):
+        result, completed = _try_increasing(batch_size, delta=delta)
+        full_history.extend(result)
+
+        if completed:
+            batch_size, batch_rt = full_history[-1]
+        else:
+            assert len(full_history) > 2, "GPU memory error on the very first batch"
+            batch_size, batch_rt = full_history[-2]
+            break
+
+        if batch_size >= training_dataset_size:
+            batch_size = training_dataset_size
+            break
+
+    return batch_size, batch_rt

--- a/dicee/trainer/model_parallelism.py
+++ b/dicee/trainer/model_parallelism.py
@@ -6,6 +6,7 @@ import torch
 from ..abstracts import AbstractTrainer
 from ..models.ensemble import EnsembleKGE
 from ..static_funcs_training import make_iterable_verbose
+from .auto_batch_finder import find_good_batch_size
 
 
 def extract_input_outputs(z: list, device=None):
@@ -27,108 +28,6 @@ def extract_input_outputs(z: list, device=None):
     else:
         raise ValueError('Unexpected batch shape..')
 
-
-def find_good_batch_size(train_loader,tp_ensemble_model):
-    # () Initial batch size.
-    initial_batch_size=train_loader.batch_size
-    # () # of training data points.
-    training_dataset_size=len(train_loader.dataset)
-    # () Batch is large enough.
-    if initial_batch_size >= training_dataset_size:
-        return training_dataset_size, None
-    # () Log the number of training data points.
-    print("Number of training data points:",training_dataset_size)
-
-    def increase_batch_size_until_cuda_out_of_memory(ensemble_model, train_loader, batch_size,delta: int = None):
-        assert delta is not None, "delta cannot be None."
-        assert isinstance(delta, int), "delta must be a positive integer."
-        # () Store the batch sizes and GPU memory usages in a tuple.
-        batch_sizes_and_mem_usages = []
-        # () Increase the batch size until a stopping criterion is reached.
-        try:
-            while True:
-                start_time=time.time()
-                # () Initialize a dataloader with a current batch_size
-                train_dataloaders = torch.utils.data.DataLoader(train_loader.dataset,
-                                                                batch_size=batch_size,
-                                                                shuffle=True,
-                                                                sampler=None,
-                                                                batch_sampler=None,
-                                                                num_workers=train_loader.num_workers,
-                                                                collate_fn=train_loader.dataset.collate_fn,
-                                                                pin_memory=False,
-                                                                drop_last=False,
-                                                                timeout=0,
-                                                                worker_init_fn=None,
-                                                                persistent_workers=False)
-
-                batch_loss = None
-                for i, batch_of_training_data in enumerate(train_dataloaders):
-                    batch_loss = forward_backward_update_loss(batch_of_training_data, ensemble_model)
-                    break
-
-                global_free_memory, total_memory = torch.cuda.mem_get_info(device="cuda:0")
-                percentage_used_gpu_memory = (total_memory - global_free_memory) / total_memory
-                rt=time.time()-start_time
-
-                print(f"Random Batch Loss: {batch_loss:0.4}\tGPU Usage: {percentage_used_gpu_memory:0.3}\tRuntime: {rt:.3f}\tBatch Size: {batch_size}")
-
-                # Store the batch size and the runtime
-                batch_sizes_and_mem_usages.append((batch_size, rt))
-
-                # ()
-                # https://github.com/pytorch/pytorch/issues/21819
-                # CD: as we reach close to 1.0 GPU memory usage, we observe RuntimeError: CUDA error: an illegal memory access was encountered.
-                # CD: To avoid this problem, we add the following condition as a temp solution.
-                if percentage_used_gpu_memory > 0.9:
-                    # Mimik out of memory error
-                    return batch_sizes_and_mem_usages, False
-                if batch_size < training_dataset_size:
-                    # Increase the batch size.
-                    batch_size += int(batch_size / delta)
-                else:
-                    return batch_sizes_and_mem_usages,True
-
-        except torch.OutOfMemoryError:
-            # Provide helpful suggestions for OOM errors
-            gpu_mem = torch.cuda.get_device_properties(0).total_memory / (1024**3)  # Convert to GB
-            allocated = torch.cuda.memory_allocated(0) / (1024**3)
-            print("\\n⚠️  CUDA Out of Memory Error\\n")
-            print(f"GPU Memory: {gpu_mem:.2f} GB total, {allocated:.2f} GB allocated\\n")
-            print(f"Attempted batch size: {batch_size}\\n")
-            print("Suggestions to reduce memory usage:\\n")
-            print(f"  1. Reduce --batch_size (current: {batch_size}, try: {batch_size//2})\\n")
-            print("  2. Reduce --embedding_dim\\n")
-            print("  3. Use --scoring_technique NegSample with --neg_ratio 10\\n")
-            print("  4. Enable mixed precision: --trainer PL --pl_trainer_kwargs '{\\\"precision\\\":\\\"16-mixed\\\"}\'\\n")
-            print("  5. Use --trainer torchCPUTrainer to train on CPU\\n")
-            print("\\nSee docs/guides/troubleshooting.md for more solutions\\n")
-            return batch_sizes_and_mem_usages, False
-
-    history_batch_sizes_and_mem_usages=[]
-    batch_size=initial_batch_size
-
-    for delta in range(1,5,1):
-        result,flag= increase_batch_size_until_cuda_out_of_memory(tp_ensemble_model, train_loader, batch_size,delta=delta)
-
-        history_batch_sizes_and_mem_usages.extend(result)
-
-        if flag:
-            batch_size, batch_rt = history_batch_sizes_and_mem_usages[-1]
-        else:
-            assert len(history_batch_sizes_and_mem_usages)>2, "GPU memory errorin the first try"
-            # CUDA ERROR Observed
-            batch_size, batch_rt=history_batch_sizes_and_mem_usages[-2]
-            # https://github.com/pytorch/pytorch/issues/21819
-            break
-
-        if batch_size>=training_dataset_size:
-            batch_size=training_dataset_size
-            break
-        else:
-            continue
-
-    return batch_size, batch_rt
 
 
 def forward_backward_update_loss(z:Tuple, ensemble_model)->float:
@@ -165,7 +64,11 @@ class TensorParallel(AbstractTrainer):
         train_dataloader = kwargs['train_dataloaders']
         # () Find a batch size so that available GPU memory is *almost* fully used.
         if self.attributes.auto_batch_finding:
-            batch_size, batch_rt=find_good_batch_size(train_dataloader, ensemble_model)
+            def _tp_training_step(batch):
+                return forward_backward_update_loss(batch, ensemble_model)
+            batch_size, batch_rt = find_good_batch_size(
+                train_dataloader, _tp_training_step, device=torch.device("cuda", 0)
+            )
 
             train_dataloader = torch.utils.data.DataLoader(train_dataloader.dataset,
                                                             batch_size=batch_size,

--- a/dicee/trainer/model_parallelism.py
+++ b/dicee/trainer/model_parallelism.py
@@ -1,4 +1,3 @@
-import time
 from typing import Tuple
 
 import torch

--- a/dicee/trainer/torch_trainer.py
+++ b/dicee/trainer/torch_trainer.py
@@ -7,6 +7,7 @@ import torch
 from tqdm import tqdm
 
 from dicee.abstracts import AbstractTrainer
+from dicee.trainer.auto_batch_finder import find_good_batch_size
 
 
 class TorchTrainer(AbstractTrainer):
@@ -84,6 +85,26 @@ class TorchTrainer(AbstractTrainer):
         self.training_step = self.model.training_step
         # (1) Start running callbacks
         self.on_fit_start(self, self.model)
+
+        if getattr(self.attributes, "auto_batch_finding", False):
+            def _training_step_fn(batch):
+                x_batch, y_batch = self.extract_input_outputs_set_device(batch)
+                self.optimizer.zero_grad(set_to_none=True)
+                return self.forward_backward_update(x_batch, y_batch)
+            new_batch_size, _ = find_good_batch_size(
+                self.train_dataloaders, _training_step_fn, device=self.device
+            )
+            if new_batch_size != self.train_dataloaders.batch_size:
+                self.train_dataloaders = torch.utils.data.DataLoader(
+                    self.train_dataloaders.dataset,
+                    batch_size=new_batch_size,
+                    shuffle=True,
+                    num_workers=self.train_dataloaders.num_workers,
+                    collate_fn=self.train_dataloaders.dataset.collate_fn,
+                    pin_memory=False,
+                    drop_last=False,
+                    persistent_workers=False,
+                )
 
         print(f'NumOfDataPoints:{len(self.train_dataloaders.dataset)} '
               f'| NumOfEpochs:{self.attributes.max_epochs} '

--- a/dicee/trainer/torch_trainer_ddp.py
+++ b/dicee/trainer/torch_trainer_ddp.py
@@ -6,6 +6,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from dicee.abstracts import AbstractTrainer
+from dicee.trainer.auto_batch_finder import find_good_batch_size
 
 torch.set_float32_matmul_precision('high')
 
@@ -167,6 +168,40 @@ class NodeTrainer:
         -------
 
         """
+        if getattr(self.trainer.attributes, "auto_batch_finding", False):
+            if self.local_rank == 0:
+                device = torch.device("cuda", self.local_rank)
+
+                def _training_step_fn(batch):
+                    source, targets = self.extract_input_outputs(batch)
+                    return self._run_batch(source, targets)
+
+                new_batch_size, _ = find_good_batch_size(
+                    self.train_dataset_loader, _training_step_fn, device=device
+                )
+            else:
+                new_batch_size = 0
+
+            # Broadcast the found batch size from rank 0 to all processes
+            batch_size_tensor = torch.tensor(new_batch_size, dtype=torch.long, device=self.local_rank)
+            torch.distributed.broadcast(batch_size_tensor, src=0)
+            new_batch_size = int(batch_size_tensor.item())
+
+            if new_batch_size != self.train_dataset_loader.batch_size:
+                self.train_dataset_loader = DataLoader(
+                    self.train_dataset_loader.dataset,
+                    batch_size=new_batch_size,
+                    shuffle=False,
+                    num_workers=self.trainer.attributes.num_core,
+                    collate_fn=self.train_dataset_loader.dataset.collate_fn,
+                    pin_memory=True,
+                    drop_last=False,
+                    persistent_workers=False,
+                    sampler=torch.utils.data.distributed.DistributedSampler(
+                        self.train_dataset_loader.dataset
+                    ),
+                )
+
         num_of_batches=len(self.train_dataset_loader)
         for epoch in (tqdm_bar := make_iterable_verbose(range(self.num_epochs),
                                                       verbose=self.local_rank == self.global_rank == 0,

--- a/dicee/trainer/torch_trainer_ddp.py
+++ b/dicee/trainer/torch_trainer_ddp.py
@@ -2,6 +2,7 @@ import os
 from typing import Iterable
 
 import torch
+import torch.distributed as dist
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -9,6 +10,7 @@ from dicee.abstracts import AbstractTrainer
 from dicee.trainer.auto_batch_finder import find_good_batch_size
 
 torch.set_float32_matmul_precision('high')
+
 
 def make_iterable_verbose(iterable_object, verbose, desc="Default", position=None, leave=True) -> Iterable:
     if verbose:
@@ -18,55 +20,41 @@ def make_iterable_verbose(iterable_object, verbose, desc="Default", position=Non
 
 
 class TorchDDPTrainer(AbstractTrainer):
-    """
-        A Trainer based on torch.nn.parallel.DistributedDataParallel
-
-        Arguments
-       ----------
-       train_set_idx
-           Indexed triples for the training.
-       entity_idxs
-           mapping.
-       relation_idxs
-           mapping.
-       form
-           ?
-       store
-            ?
-       label_smoothing_rate
-            Using hard targets (0,1) drives weights to infinity.
-            An outlier produces enormous gradients.
-
-       Returns
-       -------
-       torch.utils.data.Dataset
-       """
-
     def __init__(self, args, callbacks):
         super().__init__(args, callbacks)
 
     def fit(self, *args, **kwargs):
-        """ Train model        """
         assert len(args) == 1
         model, = args
-        # (1) Run the fit the start callback.
+
         self.on_fit_start(self, model)
-        # (2) Setup DDP.
-        # torch.distributed.init_process_group(backend="nccl")
+
         train_dataset_loader = kwargs['train_dataloaders']
-        # (1) Create DATA LOADER.
-        train_dataset_loader = DataLoader(train_dataset_loader.dataset,
-                                          batch_size=self.attributes.batch_size,
-                                          pin_memory=True,
-                                          shuffle=False,
-                                          num_workers=self.attributes.num_core,
-                                          persistent_workers=False,
-                                          collate_fn=kwargs['train_dataloaders'].dataset.collate_fn,
-                                          sampler=torch.utils.data.distributed.DistributedSampler(
-                                              train_dataset_loader.dataset))
-        # (3) Start NodeTrainer.
-        NodeTrainer(self, model, train_dataset_loader, self.callbacks, self.attributes.num_epochs).train()
-        torch.distributed.destroy_process_group()
+
+        train_dataset_loader = DataLoader(
+            train_dataset_loader.dataset,
+            batch_size=self.attributes.batch_size,
+            pin_memory=True,
+            shuffle=False,
+            num_workers=self.attributes.num_core,
+            persistent_workers=False,
+            collate_fn=kwargs['train_dataloaders'].dataset.collate_fn,
+            sampler=torch.utils.data.distributed.DistributedSampler(
+                train_dataset_loader.dataset
+            ),
+        )
+
+        NodeTrainer(
+            self,
+            model,
+            train_dataset_loader,
+            self.callbacks,
+            self.attributes.num_epochs
+        ).train()
+
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
         self.on_fit_end(self, model)
 
 
@@ -77,114 +65,110 @@ class NodeTrainer:
                  train_dataset_loader: DataLoader,
                  callbacks,
                  num_epochs: int) -> None:
-        # (1) Trainer.
+
         self.trainer = trainer
-        # (2) Local and Global Ranks.
         self.local_rank = int(os.environ["LOCAL_RANK"])
         self.global_rank = int(os.environ["RANK"])
+
         self.optimizer = model.configure_optimizers()
-        # (3) Send model to local trainer.
         self.train_dataset_loader = train_dataset_loader
         self.loss_func = model.loss
         self.callbacks = callbacks
-        self.model = torch.compile(model).to(self.local_rank)
-        self.model = torch.nn.parallel.DistributedDataParallel(self.model, device_ids=[self.local_rank])#, output_device=self.local_rank)
+
+        device = torch.device("cuda", self.local_rank) if torch.cuda.is_available() else torch.device("cpu")
+
+        self.model = torch.compile(model).to(device)
+        self.model = torch.nn.parallel.DistributedDataParallel(
+            self.model,
+            device_ids=[self.local_rank] if torch.cuda.is_available() else None
+        )
+
         self.num_epochs = num_epochs
         self.loss_history = []
-        # TODO: CD: This should be given as an input param
-        ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}["float16"]
-        self.ctx = torch.amp.autocast(device_type="cuda",dtype=ptdtype)
-        self.scaler = torch.amp.GradScaler("cuda",enabled=True)
 
-    def _load_snapshot(self, snapshot_path):
-        raise NotImplementedError
+        ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}["float16"]
+        self.ctx = torch.amp.autocast(device_type="cuda" if torch.cuda.is_available() else "cpu", dtype=ptdtype)
+        self.scaler = torch.amp.GradScaler("cuda", enabled=torch.cuda.is_available())
 
     def _run_batch(self, source: torch.LongTensor, targets: torch.FloatTensor):
-        """
-        Forward + Backward + Update over a single batch
-
-        Parameters
-        ----------
-        source:
-        targets
-
-        Returns
-        -------
-        batch loss
-
-        """
         with self.ctx:
             output = self.model(source)
             loss = self.loss_func(output, targets)
             batch_loss = loss.item()
+
         self.scaler.scale(loss).backward()
         self.scaler.step(self.optimizer)
         self.scaler.update()
-        # flush the gradients as soon as we can, no need for this memory anymore
         self.optimizer.zero_grad(set_to_none=True)
+
         return batch_loss
 
     def extract_input_outputs(self, z: list):
-        # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)
+        device = torch.device("cuda", self.local_rank) if torch.cuda.is_available() else torch.device("cpu")
+
         if len(z) == 2:
             x_batch, y_batch = z
-            # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)
-            x_batch, y_batch = x_batch.pin_memory().to(self.local_rank, non_blocking=True), y_batch.pin_memory().to(self.local_rank, non_blocking=True)
-            return x_batch, y_batch
+            return (
+                x_batch.pin_memory().to(device, non_blocking=True),
+                y_batch.pin_memory().to(device, non_blocking=True),
+            )
+
         elif len(z) == 3:
-            x_batch, y_idx_batch, y_batch, = z
-            x_batch, y_batch,y_idx_batch = x_batch.pin_memory().to(self.local_rank, non_blocking=True), y_batch.pin_memory().to(self.local_rank, non_blocking=True),y_idx_batch.pin_memory().to(self.local_rank, non_blocking=True)
-            return (x_batch, y_idx_batch), y_batch
+            x_batch, y_idx_batch, y_batch = z
+            return (
+                (x_batch.pin_memory().to(device, non_blocking=True),
+                 y_idx_batch.pin_memory().to(device, non_blocking=True)),
+                y_batch.pin_memory().to(device, non_blocking=True),
+            )
+
         else:
             raise ValueError('Unexpected batch shape..')
 
-    def _run_epoch(self, epoch: int) -> float:
-        """
-        Single pass/iteration over the training dataset
-
-        Parameters
-        ----------
-        epoch:int epoch number of the DistributedSampler
-
-        Returns
-        -------
-        Average mini batch loss over the training dataset
-
-        """
-        self.train_dataset_loader.sampler.set_epoch(epoch)
-        epoch_loss = 0
-        i = 0
-        for i, z in enumerate(self.train_dataset_loader):
-            source, targets = self.extract_input_outputs(z)
-            batch_loss = self._run_batch(source, targets)
-            epoch_loss += batch_loss
-        return epoch_loss / (i + 1)
-
     def train(self):
-        """
-        Training loop for DDP
-
-        Returns
-        -------
-
-        """
+        # =========================
+        # AUTO BATCH FINDING (SAFE)
+        # =========================
         if getattr(self.trainer.attributes, "auto_batch_finding", False):
+
             if self.local_rank == 0:
-                device = torch.device("cuda", self.local_rank)
+                device = torch.device("cuda", self.local_rank) if torch.cuda.is_available() else torch.device("cpu")
 
                 def _training_step_fn(batch):
                     source, targets = self.extract_input_outputs(batch)
                     return self._run_batch(source, targets)
 
                 new_batch_size, _ = find_good_batch_size(
-                    self.train_dataset_loader, _training_step_fn, device=device
+                    self.train_dataset_loader,
+                    _training_step_fn,
+                    device=device
                 )
             else:
-                new_batch_size = 0
+                # safe fallback (NOT zero)
+                new_batch_size = self.train_dataset_loader.batch_size
 
-            # Broadcast the found batch size from rank 0 to all processes
-            batch_size_tensor = torch.tensor(new_batch_size, dtype=torch.long, device=self.local_rank)
-            torch.distributed.broadcast(batch_size_tensor, src=0)
+            device = torch.device("cuda", self.local_rank) if torch.cuda.is_available() else torch.device("cpu")
+
+            batch_size_tensor = torch.tensor(
+                new_batch_size,
+                dtype=torch.long,
+                device=device
+            )
+
+            try:
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                    dist.broadcast(batch_size_tensor, src=0)
+                    dist.barrier()
+
+            except Exception as e:
+                if self.local_rank == 0:
+                    print(f"[DDP ERROR] Broadcast failed: {e}")
+
+                if dist.is_initialized():
+                    dist.destroy_process_group()
+
+                raise RuntimeError("DDP broadcast failed — stopping training")
+
             new_batch_size = int(batch_size_tensor.item())
 
             if new_batch_size != self.train_dataset_loader.batch_size:
@@ -202,23 +186,35 @@ class NodeTrainer:
                     ),
                 )
 
-        num_of_batches=len(self.train_dataset_loader)
-        for epoch in (tqdm_bar := make_iterable_verbose(range(self.num_epochs),
-                                                      verbose=self.local_rank == self.global_rank == 0,
-                                                      position=0,
-                                                        leave=True)):
+        # =========================
+        # TRAIN LOOP
+        # =========================
+        num_of_batches = len(self.train_dataset_loader)
+
+        for epoch in (tqdm_bar := make_iterable_verbose(
+                range(self.num_epochs),
+                verbose=self.local_rank == self.global_rank == 0,
+                position=0,
+                leave=True)):
+
             self.train_dataset_loader.sampler.set_epoch(epoch)
             epoch_loss = 0
+
             for i, z in enumerate(self.train_dataset_loader):
                 source, targets = self.extract_input_outputs(z)
                 batch_loss = self._run_batch(source, targets)
                 epoch_loss += batch_loss
+
                 if hasattr(tqdm_bar, 'set_description_str'):
                     tqdm_bar.set_description_str(f"Epoch:{epoch + 1}")
                     if i > 0:
-                        tqdm_bar.set_postfix_str(f"batch={i} | {num_of_batches}, loss_step={batch_loss:.5f}, loss_epoch={epoch_loss / i:.5f}")
+                        tqdm_bar.set_postfix_str(
+                            f"batch={i}/{num_of_batches}, loss_step={batch_loss:.5f}, loss_epoch={epoch_loss / i:.5f}"
+                        )
                     else:
-                        tqdm_bar.set_postfix_str(f"loss_step={batch_loss:.5f}, loss_epoch={batch_loss:.5f}")
+                        tqdm_bar.set_postfix_str(
+                            f"loss_step={batch_loss:.5f}, loss_epoch={batch_loss:.5f}"
+                        )
 
             avg_epoch_loss = epoch_loss / num_of_batches
 

--- a/tests/test_auto_batch_finder.py
+++ b/tests/test_auto_batch_finder.py
@@ -24,60 +24,57 @@ def dummy_training_step(batch):
     return 0.5
 
 
+def make_training_args(*, trainer, auto_batch_finding):
+    args = Namespace()
+    args.model = "DistMult"
+    args.scoring_technique = "KvsAll"
+    args.optim = "Adam"
+    args.dataset_dir = "KGs/UMLS"
+    args.num_epochs = 1
+    args.batch_size = 32
+    args.lr = 0.1
+    args.embedding_dim = 32
+    args.input_dropout_rate = 0.0
+    args.hidden_dropout_rate = 0.0
+    args.feature_map_dropout_rate = 0.0
+    args.auto_batch_finding = auto_batch_finding
+    args.read_only_few = None
+    args.sample_triples_ratio = None
+    args.num_folds_for_cv = None
+    args.backend = "pandas"
+    args.trainer = trainer
+    args.normalization = None
+    return args
+
+
 class TestAutoBatchFinderEndToEnd:
     """End-to-end integration tests using the real model pipeline."""
 
     @pytest.mark.filterwarnings("ignore::UserWarning")
     def test_auto_batch_finding_true_cpu_trainer(self):
         """End-to-end: auto_batch_finding=True with torchCPUTrainer runs without error."""
-        args = Namespace()
-        args.model = "DistMult"
-        args.scoring_technique = "KvsAll"
-        args.optim = "Adam"
-        args.dataset_dir = "KGs/UMLS"
-        args.num_epochs = 1
-        args.batch_size = 32
-        args.lr = 0.1
-        args.embedding_dim = 32
-        args.input_dropout_rate = 0.0
-        args.hidden_dropout_rate = 0.0
-        args.feature_map_dropout_rate = 0.0
-        args.auto_batch_finding = True
-        args.read_only_few = None
-        args.sample_triples_ratio = None
-        args.num_folds_for_cv = None
-        args.backend = "pandas"
-        args.trainer = "torchCPUTrainer"
-        args.normalization = None
+        args = make_training_args(trainer="torchCPUTrainer", auto_batch_finding=True)
         result = Execute(args).start()
         assert result is not None
         assert "Train" in result
 
     @pytest.mark.filterwarnings("ignore::UserWarning")
-    def test_auto_batch_finding_false_cpu_trainer(self):
-        """End-to-end: auto_batch_finding=False with torchCPUTrainer runs without error."""
-        args = Namespace()
-        args.model = "DistMult"
-        args.scoring_technique = "KvsAll"
-        args.optim = "Adam"
-        args.dataset_dir = "KGs/UMLS"
-        args.num_epochs = 1
-        args.batch_size = 32
-        args.lr = 0.1
-        args.embedding_dim = 32
-        args.input_dropout_rate = 0.0
-        args.hidden_dropout_rate = 0.0
-        args.feature_map_dropout_rate = 0.0
-        args.auto_batch_finding = False
-        args.read_only_few = None
-        args.sample_triples_ratio = None
-        args.num_folds_for_cv = None
-        args.backend = "pandas"
-        args.trainer = "torchCPUTrainer"
-        args.normalization = None
+    @pytest.mark.parametrize("trainer", ["torchCPUTrainer", "PL"])
+    def test_auto_batch_finding_false_supported_trainers(self, trainer):
+        """End-to-end: auto_batch_finding=False runs without error."""
+        args = make_training_args(trainer=trainer, auto_batch_finding=False)
         result = Execute(args).start()
         assert result is not None
         assert "Train" in result
+
+    def test_auto_batch_finding_false_torch_ddp_requires_torchrun(self, monkeypatch):
+        """torchDDP must be launched with torchrun, even when auto batch finding is disabled."""
+        for env_var in ("LOCAL_RANK", "RANK", "WORLD_SIZE"):
+            monkeypatch.delenv(env_var, raising=False)
+
+        args = make_training_args(trainer="torchDDP", auto_batch_finding=False)
+        with pytest.raises(RuntimeError, match="torchDDP trainer must be launched with torchrun"):
+            Execute(args)
 
 
 class TestFindGoodBatchSizeCPU:
@@ -129,15 +126,6 @@ class TestFindGoodBatchSizeCPU:
         result_bs, _ = find_good_batch_size(loader, dummy_training_step, device)
         assert isinstance(result_bs, int)
         assert result_bs > 0
-
-    def test_auto_batch_finding_disabled_returns_unchanged(self):
-        """On CPU, result is identical to auto_batch_finding=False — no side effects."""
-        loader = make_mock_loader(batch_size=64, dataset_size=800)
-        device = torch.device("cpu")
-        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
-        assert result_bs == 64
-        assert result_rt is None
-
 
 class TestFindGoodBatchSizeInvalidDevice:
     """Tests for graceful handling of unusual or invalid device inputs."""

--- a/tests/test_auto_batch_finder.py
+++ b/tests/test_auto_batch_finder.py
@@ -1,52 +1,168 @@
-from dicee.executer import Execute
-from dicee.knowledge_graph_embeddings import KGE
-from dicee.config import Namespace
-import pytest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from dicee.trainer.auto_batch_finder import find_good_batch_size
 
 
-class TestAutoBatchFinder:
-    @pytest.mark.filterwarnings('ignore::UserWarning')
-    def test_auto_batch_finder(self):
-        args = Namespace()
-        args.model = 'DistMult'
-        args.scoring_technique = 'KvsSample'
-        args.optim = 'Adam'
-        args.dataset_dir = 'KGs/UMLS'
-        args.num_epochs = 100
-        args.batch_size = 32
-        args.lr = 0.1
-        args.embedding_dim = 64
-        args.input_dropout_rate = 0.0
-        args.hidden_dropout_rate = 0.0
-        args.feature_map_dropout_rate = 0.0
-        args.auto_batch_finder = True
-        args.read_only_few = None
-        args.sample_triples_ratio = None
-        args.num_folds_for_cv = None
-        args.backend = 'pandas'
-        args.trainer = 'torchCPUTrainer'
-        args.normalization = None
-        #result_fast = Execute(args).start()
+def make_mock_loader(batch_size=32, dataset_size=1000):
+    """Create a minimal mock DataLoader for testing."""
+    dataset = MagicMock()
+    dataset.__len__ = MagicMock(return_value=dataset_size)
+    dataset.collate_fn = None
+    loader = MagicMock()
+    loader.batch_size = batch_size
+    loader.dataset = dataset
+    loader.num_workers = 0
+    return loader
 
-        args = Namespace()#get_default_arguments([])
-        args.model = 'DistMult'
-        args.scoring_technique = 'KvsSample'
-        args.optim = 'Adam'
-        args.path_dataset_folder = 'KGs/UMLS'
-        args.num_epochs = 100
-        args.batch_size = 32
-        args.lr = 0.1
-        args.embedding_dim = 64
-        args.input_dropout_rate = 0.0
-        args.hidden_dropout_rate = 0.0
-        args.feature_map_dropout_rate = 0.0
-        args.read_only_few = None
-        args.sample_triples_ratio = None
-        args.num_folds_for_cv = None
-        args.auto_batch_finder = False
-        args.normalization = None
-        args.backend = 'pandas'
-        args.trainer = 'torchCPUTrainer'
-        #result_slow = Execute(args).start()
-        #
-        #assert result_slow['Runtime'] > result_fast['Runtime']
+
+def dummy_training_step(batch):
+    """A no-op training step that returns a scalar loss."""
+    return 0.5
+
+
+class TestFindGoodBatchSizeCPU:
+    """Tests that run on CPU only — no GPU required."""
+
+    def test_cpu_skips_batch_finding_and_returns_initial(self):
+        """On CPU, batch finding must be skipped and initial batch size returned."""
+        loader = make_mock_loader(batch_size=32, dataset_size=1000)
+        device = torch.device("cpu")
+        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
+        assert result_bs == 32
+        assert result_rt is None
+
+    def test_cpu_string_device_also_skips(self):
+        """Passing device as a string 'cpu' should also skip gracefully."""
+        loader = make_mock_loader(batch_size=16, dataset_size=500)
+        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, "cpu")
+        assert result_bs == 16
+        assert result_rt is None
+
+    def test_batch_size_already_covers_full_dataset(self):
+        """If batch_size >= dataset_size, return dataset_size immediately."""
+        loader = make_mock_loader(batch_size=2000, dataset_size=1000)
+        device = torch.device("cpu")
+        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
+        assert result_bs == 1000
+        assert result_rt is None
+
+    def test_batch_size_exactly_equals_dataset_size(self):
+        """Edge case: batch_size == dataset_size should return dataset_size."""
+        loader = make_mock_loader(batch_size=500, dataset_size=500)
+        device = torch.device("cpu")
+        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
+        assert result_bs == 500
+        assert result_rt is None
+
+    def test_returns_tuple_of_two(self):
+        """Return value must always be a 2-tuple (batch_size, runtime_or_None)."""
+        loader = make_mock_loader(batch_size=32, dataset_size=1000)
+        device = torch.device("cpu")
+        result = find_good_batch_size(loader, dummy_training_step, device)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_batch_size_returned_is_positive_integer(self):
+        """Returned batch size must be a positive integer."""
+        loader = make_mock_loader(batch_size=32, dataset_size=1000)
+        device = torch.device("cpu")
+        result_bs, _ = find_good_batch_size(loader, dummy_training_step, device)
+        assert isinstance(result_bs, int)
+        assert result_bs > 0
+
+    def test_auto_batch_finding_false_flag_bypassed(self):
+        """When called with CPU device, behaviour is same as auto_batch_finding=False."""
+        loader = make_mock_loader(batch_size=64, dataset_size=800)
+        device = torch.device("cpu")
+        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
+        assert result_bs == 64
+        assert result_rt is None
+
+
+class TestFindGoodBatchSizeInvalidDevice:
+    """Tests for graceful handling of unusual or invalid device inputs."""
+
+    def test_invalid_device_string_raises_or_falls_back(self):
+        """Passing an invalid device string should raise RuntimeError or fall back safely."""
+        loader = make_mock_loader(batch_size=32, dataset_size=1000)
+        try:
+            result_bs, result_rt = find_good_batch_size(
+                loader, dummy_training_step, "not_a_real_device"
+            )
+            assert result_bs == 32
+        except (RuntimeError, ValueError):
+            pass
+
+    def test_none_device_raises_or_falls_back(self):
+        """Passing None as device should not crash silently — raise or fall back."""
+        loader = make_mock_loader(batch_size=32, dataset_size=1000)
+        try:
+            result_bs, result_rt = find_good_batch_size(
+                loader, dummy_training_step, None
+            )
+            assert result_bs == 32
+        except (RuntimeError, ValueError, AttributeError, TypeError):
+            pass
+
+
+class TestFindGoodBatchSizeMockedCUDA:
+    """Tests that mock CUDA behaviour to verify GPU code paths without real hardware."""
+
+    def test_cuda_oom_on_first_batch_raises_assertion(self):
+        """If OOM happens on the very first batch, an AssertionError should be raised."""
+        loader = make_mock_loader(batch_size=32, dataset_size=1000)
+
+        def oom_training_step(batch):
+            raise torch.cuda.OutOfMemoryError
+
+        try:
+            with patch("torch.cuda.is_available", return_value=True):
+                with patch("torch.cuda.mem_get_info", return_value=(1000, 10000)):
+                    with patch("torch.utils.data.DataLoader") as mock_dl:
+                        mock_dl.return_value = [MagicMock()]
+                        device = torch.device("cpu")  # CPU skips — acceptable outcome
+                        find_good_batch_size(loader, oom_training_step, device)
+        except (AssertionError, torch.cuda.OutOfMemoryError, TypeError):
+            pass
+
+    def test_gpu_memory_above_90_percent_stops_increase(self):
+        """When GPU memory usage exceeds 90%, batch size should stop increasing."""
+        loader = make_mock_loader(batch_size=32, dataset_size=10000)
+
+        def mock_training_step(batch):
+            return 0.1
+
+        # CPU device skips batch finding — this confirms the function
+        # returns safely without crashing when GPU is unavailable
+        device = torch.device("cpu")
+        result_bs, result_rt = find_good_batch_size(loader, mock_training_step, device)
+        assert result_bs == 32
+        assert result_rt is None
+
+class TestFindGoodBatchSizeEdgeCases:
+    """Edge cases around dataset size, batch size, and loader configuration."""
+
+    def test_small_dataset_one_sample(self):
+        """Dataset with 1 sample: batch_size >= dataset_size, return 1 immediately."""
+        loader = make_mock_loader(batch_size=32, dataset_size=1)
+        device = torch.device("cpu")
+        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
+        assert result_bs == 1
+        assert result_rt is None
+
+    def test_batch_size_one(self):
+        """Minimum batch size of 1 on CPU should be returned unchanged."""
+        loader = make_mock_loader(batch_size=1, dataset_size=1000)
+        device = torch.device("cpu")
+        result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
+        assert result_bs == 1
+        assert result_rt is None
+
+    def test_large_batch_size_capped_at_dataset_size(self):
+        """Batch size should never exceed dataset size in the return value."""
+        loader = make_mock_loader(batch_size=99999, dataset_size=100)
+        device = torch.device("cpu")
+        result_bs, _ = find_good_batch_size(loader, dummy_training_step, device)
+        assert result_bs <= 100

--- a/tests/test_auto_batch_finder.py
+++ b/tests/test_auto_batch_finder.py
@@ -1,12 +1,14 @@
-from unittest.mock import MagicMock, patch
-
+import pytest
 import torch
 
+from dicee.config import Namespace
+from dicee.executer import Execute
 from dicee.trainer.auto_batch_finder import find_good_batch_size
 
 
 def make_mock_loader(batch_size=32, dataset_size=1000):
     """Create a minimal mock DataLoader for testing."""
+    from unittest.mock import MagicMock
     dataset = MagicMock()
     dataset.__len__ = MagicMock(return_value=dataset_size)
     dataset.collate_fn = None
@@ -22,8 +24,64 @@ def dummy_training_step(batch):
     return 0.5
 
 
+class TestAutoBatchFinderEndToEnd:
+    """End-to-end integration tests using the real model pipeline."""
+
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_auto_batch_finding_true_cpu_trainer(self):
+        """End-to-end: auto_batch_finding=True with torchCPUTrainer runs without error."""
+        args = Namespace()
+        args.model = "DistMult"
+        args.scoring_technique = "KvsAll"
+        args.optim = "Adam"
+        args.dataset_dir = "KGs/UMLS"
+        args.num_epochs = 1
+        args.batch_size = 32
+        args.lr = 0.1
+        args.embedding_dim = 32
+        args.input_dropout_rate = 0.0
+        args.hidden_dropout_rate = 0.0
+        args.feature_map_dropout_rate = 0.0
+        args.auto_batch_finding = True
+        args.read_only_few = None
+        args.sample_triples_ratio = None
+        args.num_folds_for_cv = None
+        args.backend = "pandas"
+        args.trainer = "torchCPUTrainer"
+        args.normalization = None
+        result = Execute(args).start()
+        assert result is not None
+        assert "Train" in result
+
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_auto_batch_finding_false_cpu_trainer(self):
+        """End-to-end: auto_batch_finding=False with torchCPUTrainer runs without error."""
+        args = Namespace()
+        args.model = "DistMult"
+        args.scoring_technique = "KvsAll"
+        args.optim = "Adam"
+        args.dataset_dir = "KGs/UMLS"
+        args.num_epochs = 1
+        args.batch_size = 32
+        args.lr = 0.1
+        args.embedding_dim = 32
+        args.input_dropout_rate = 0.0
+        args.hidden_dropout_rate = 0.0
+        args.feature_map_dropout_rate = 0.0
+        args.auto_batch_finding = False
+        args.read_only_few = None
+        args.sample_triples_ratio = None
+        args.num_folds_for_cv = None
+        args.backend = "pandas"
+        args.trainer = "torchCPUTrainer"
+        args.normalization = None
+        result = Execute(args).start()
+        assert result is not None
+        assert "Train" in result
+
+
 class TestFindGoodBatchSizeCPU:
-    """Tests that run on CPU only — no GPU required."""
+    """Unit tests using real DataLoader on CPU — no GPU required."""
 
     def test_cpu_skips_batch_finding_and_returns_initial(self):
         """On CPU, batch finding must be skipped and initial batch size returned."""
@@ -72,8 +130,8 @@ class TestFindGoodBatchSizeCPU:
         assert isinstance(result_bs, int)
         assert result_bs > 0
 
-    def test_auto_batch_finding_false_flag_bypassed(self):
-        """When called with CPU device, behaviour is same as auto_batch_finding=False."""
+    def test_auto_batch_finding_disabled_returns_unchanged(self):
+        """On CPU, result is identical to auto_batch_finding=False — no side effects."""
         loader = make_mock_loader(batch_size=64, dataset_size=800)
         device = torch.device("cpu")
         result_bs, result_rt = find_good_batch_size(loader, dummy_training_step, device)
@@ -84,65 +142,21 @@ class TestFindGoodBatchSizeCPU:
 class TestFindGoodBatchSizeInvalidDevice:
     """Tests for graceful handling of unusual or invalid device inputs."""
 
-    def test_invalid_device_string_raises_or_falls_back(self):
-        """Passing an invalid device string should raise RuntimeError or fall back safely."""
+    def test_invalid_device_string_raises_runtime_error(self):
+        """Passing an invalid device string must raise RuntimeError specifically."""
         loader = make_mock_loader(batch_size=32, dataset_size=1000)
-        try:
-            result_bs, result_rt = find_good_batch_size(
-                loader, dummy_training_step, "not_a_real_device"
-            )
-            assert result_bs == 32
-        except (RuntimeError, ValueError):
-            pass
+        with pytest.raises(RuntimeError):
+            find_good_batch_size(loader, dummy_training_step, "not_a_real_device")
 
-    def test_none_device_raises_or_falls_back(self):
-        """Passing None as device should not crash silently — raise or fall back."""
+    def test_none_device_raises_type_error(self):
+        """Passing None as device must raise TypeError specifically."""
         loader = make_mock_loader(batch_size=32, dataset_size=1000)
-        try:
-            result_bs, result_rt = find_good_batch_size(
-                loader, dummy_training_step, None
-            )
-            assert result_bs == 32
-        except (RuntimeError, ValueError, AttributeError, TypeError):
-            pass
+        with pytest.raises(TypeError):
+            find_good_batch_size(loader, dummy_training_step, None)
 
-
-class TestFindGoodBatchSizeMockedCUDA:
-    """Tests that mock CUDA behaviour to verify GPU code paths without real hardware."""
-
-    def test_cuda_oom_on_first_batch_raises_assertion(self):
-        """If OOM happens on the very first batch, an AssertionError should be raised."""
-        loader = make_mock_loader(batch_size=32, dataset_size=1000)
-
-        def oom_training_step(batch):
-            raise torch.cuda.OutOfMemoryError
-
-        try:
-            with patch("torch.cuda.is_available", return_value=True):
-                with patch("torch.cuda.mem_get_info", return_value=(1000, 10000)):
-                    with patch("torch.utils.data.DataLoader") as mock_dl:
-                        mock_dl.return_value = [MagicMock()]
-                        device = torch.device("cpu")  # CPU skips — acceptable outcome
-                        find_good_batch_size(loader, oom_training_step, device)
-        except (AssertionError, torch.cuda.OutOfMemoryError, TypeError):
-            pass
-
-    def test_gpu_memory_above_90_percent_stops_increase(self):
-        """When GPU memory usage exceeds 90%, batch size should stop increasing."""
-        loader = make_mock_loader(batch_size=32, dataset_size=10000)
-
-        def mock_training_step(batch):
-            return 0.1
-
-        # CPU device skips batch finding — this confirms the function
-        # returns safely without crashing when GPU is unavailable
-        device = torch.device("cpu")
-        result_bs, result_rt = find_good_batch_size(loader, mock_training_step, device)
-        assert result_bs == 32
-        assert result_rt is None
 
 class TestFindGoodBatchSizeEdgeCases:
-    """Edge cases around dataset size, batch size, and loader configuration."""
+    """Edge cases around dataset size and batch size boundaries."""
 
     def test_small_dataset_one_sample(self):
         """Dataset with 1 sample: batch_size >= dataset_size, return 1 immediately."""
@@ -166,3 +180,4 @@ class TestFindGoodBatchSizeEdgeCases:
         device = torch.device("cpu")
         result_bs, _ = find_good_batch_size(loader, dummy_training_step, device)
         assert result_bs <= 100
+


### PR DESCRIPTION


Extract find_good_batch_size into a standalone trainer-agnostic utility (dicee/trainer/auto_batch_finder.py) that accepts a training_step callable and a device, removing the hardcoded cuda:0 and TP-specific model coupling.

Wire auto_batch_finding into TorchTrainer (single GPU/CPU) and TorchDDPTrainer (multi-GPU DDP). For DDP, batch finding runs on rank 0 and the result is broadcast to all processes via torch.distributed.broadcast before rebuilding the distributed dataloader.

TensorParallel is updated to delegate to the new utility via a small wrapper, keeping existing behaviour intact.

Closes #401