### PR TITLE
Add citation for Multiple Run Ensemble Learning paper

### DIFF
--- a/.github/agents/dicee_agent.agent.md
+++ b/.github/agents/dicee_agent.agent.md
@@ -43,11 +43,12 @@ When a task spans multiple domains, invoke sub-agents **sequentially** in depend
 ## Framework Quick Reference
 
 - **Models**: Keci, ComplEx, DistMult, TransE, QMult, OMult, BytE, CoKE, PykeenKGE (and more)
-- **Trainers**: `torchCPUTrainer` (default), `PL` (multi-GPU), `torchDDP` (native DDP), `TP` (tensor parallel)
+- **Trainers**: `torchCPUTrainer` (default), `PL` (multi-GPU), `torchDDP` (native DDP), `TP` (tensor parallel ensemble)
 - **Scoring techniques**: `KvsAll` (default), `NegSample`, `1vsAll`, `KvsSample`, `AllvsAll`
 - **Key entry point**: `dicee --dataset_dir "KGs/UMLS" --model Keci`
 - **Inference entry point**: `from dicee import KGE; model = KGE(path="Experiments/...")`
 - **Experiment output**: `Experiments/<timestamp>/` — `model.pt`, `eval_report.json`, `configuration.json`
+- **Tensor Parallelism**: `TP` trainer implements "Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings"
 
 ## Constraints
 - ALWAYS delegate to a sub-agent rather than answering complex implementation questions yourself

--- a/.github/agents/kge-trainer.agent.md
+++ b/.github/agents/kge-trainer.agent.md
@@ -39,7 +39,9 @@ You are a training expert for the **dicee Knowledge Graph Embedding framework**.
 | 1 GPU | `PL` with `CUDA_VISIBLE_DEVICES=0` |
 | Multiple GPUs (same machine) | `PL` |
 | Native multi-GPU | `torchDDP` via `torchrun` |
-| Tensor parallelism | `TP` |
+| Tensor parallelism (ensemble) | `TP` |
+
+> **Note:** `TP` implements "Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings"
 
 ### Scoring technique selection
 | KG size | `--scoring_technique` | Notes |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,7 +66,7 @@ The `args` dict passed to `__init__` comes from `config.Namespace.__dict__`.
 | `torchCPUTrainer` | `TorchTrainer` | CPU or single GPU |
 | `PL` | PyTorch Lightning | Multi-GPU, recommended default |
 | `torchDDP` | `TorchDDPTrainer` | Native DDP via `torchrun` |
-| `TP` | `TensorParallel` | Tensor parallelism (1 model per GPU) |
+| `TP` | `TensorParallel` | Tensor parallelism (1 model per GPU) — implements "Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings" |
 
 Multi-GPU with PL uses all visible CUDA devices automatically.
 Use `CUDA_VISIBLE_DEVICES=0` to restrict to one GPU.

--- a/.github/skills/run-training/SKILL.md
+++ b/.github/skills/run-training/SKILL.md
@@ -24,7 +24,9 @@ argument-hint: "Describe your setup: dataset, hardware (CPU/GPU count), scoring 
 | Multi-GPU (recommended) | `PL` | `dicee --trainer PL ...` |
 | Native DDP (multi-GPU) | `torchDDP` | `torchrun --standalone --nnodes=1 --nproc_per_node=gpu dicee --trainer torchDDP ...` |
 | Multi-node DDP | `torchDDP` or `PL` | `torchrun --nnodes 2 --nproc_per_node=gpu ...` |
-| Tensor Parallelism | `TP` | `dicee --trainer TP ...` |
+| Tensor Parallelism (Ensemble) | `TP` | `dicee --trainer TP ...` |
+
+> **Note:** The `TP` (Tensor Parallelism) trainer implements the approach from "Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings"
 
 **Rules:**
 - `PL` trainer uses all visible CUDA devices automatically — restrict with `CUDA_VISIBLE_DEVICES=0`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A KGE model can be trained with a state-of-the-art training technique ```--train
 dicee --dataset_dir "KGs/UMLS" --trainer "torchCPUTrainer" --scoring_technique KvsAll --model "Keci" --eval_model "train_val_test"
 # Distributed Data Parallelism
 dicee --dataset_dir "KGs/UMLS" --trainer "PL" --scoring_technique KvsAll --model "Keci" --eval_model "train_val_test"
-# Tensor Parallelism
+# Tensor Parallelism (implements Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings)
 dicee --dataset_dir "KGs/UMLS" --trainer "TP" --scoring_technique KvsAll --model "Keci" --eval_model "train_val_test"
 # Distributed Data Parallelism in native torch
 OMP_NUM_THREADS=1 torchrun --standalone --nnodes=1 --nproc_per_node=gpu dicee --dataset_dir "KGs/UMLS" --model Keci --eval_model "train_val_test" --trainer "torchDDP" --scoring_technique KvsAll --path_to_store_single_run "UMLS_torchDDP"
@@ -1114,6 +1114,13 @@ docker run --rm -v ~/.local/share/dicee/KGs:/dicee/KGs dice-embeddings ./main.py
 Currently, we are working on our manuscript describing our framework. 
 If you really like our work and want to cite it now, feel free to choose one :) 
 ```
+# Tensor Parallelism / Model Parallelism
+@article{demir2024ensemble,
+  title={Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings},
+  author={Demir, Caglar and Ngonga Ngomo, Axel-Cyrille},
+  journal={Accepted},
+  year={2024}
+}
 #ASWA
 @inproceedings{sapkota2025parameter,
   author    = {Sapkota, Rupesh and Demir, Caglar and Sharma, Arnab and Ngonga Ngomo, Axel-Cyrille},

--- a/README.md
+++ b/README.md
@@ -1114,13 +1114,6 @@ docker run --rm -v ~/.local/share/dicee/KGs:/dicee/KGs dice-embeddings ./main.py
 Currently, we are working on our manuscript describing our framework. 
 If you really like our work and want to cite it now, feel free to choose one :) 
 ```
-# Tensor Parallelism / Model Parallelism
-@article{demir2024ensemble,
-  title={Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings},
-  author={Demir, Caglar and Ngonga Ngomo, Axel-Cyrille},
-  journal={Accepted},
-  year={2024}
-}
 #ASWA
 @inproceedings{sapkota2025parameter,
   author    = {Sapkota, Rupesh and Demir, Caglar and Sharma, Arnab and Ngonga Ngomo, Axel-Cyrille},

--- a/dicee/config.py
+++ b/dicee/config.py
@@ -67,7 +67,7 @@ class Namespace(argparse.Namespace):
         """separator for extracting head, relation and tail from a triple"""
 
         self.trainer: str = 'torchCPUTrainer'
-        """Trainer for knowledge graph embedding model"""
+        """Trainer for knowledge graph embedding model. Options: 'torchCPUTrainer' (CPU/single GPU), 'PL' (PyTorch Lightning multi-GPU), 'torchDDP' (native DDP), 'TP' (Tensor Parallelism - implements 'Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings')"""
 
         self.scoring_technique: str = 'KvsAll'
         """Scoring technique for knowledge graph embedding models"""

--- a/dicee/trainer/model_parallelism.py
+++ b/dicee/trainer/model_parallelism.py
@@ -2,6 +2,7 @@
 
 This module implements the tensor parallelism training strategy described in:
   "Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings"
+   https://arxiv.org/abs/2104.05003
 
 The TensorParallel trainer creates an ensemble of models, each trained on a separate GPU,
 allowing efficient utilization of multi-GPU systems through model parallelism.

--- a/dicee/trainer/model_parallelism.py
+++ b/dicee/trainer/model_parallelism.py
@@ -1,3 +1,11 @@
+"""Tensor Parallelism trainer for ensemble knowledge graph embeddings.
+
+This module implements the tensor parallelism training strategy described in:
+  "Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings"
+
+The TensorParallel trainer creates an ensemble of models, each trained on a separate GPU,
+allowing efficient utilization of multi-GPU systems through model parallelism.
+"""
 from typing import Tuple
 
 import torch


### PR DESCRIPTION
- Added paper citation in README.md How to cite section
- Updated Tensor Parallelism section in README.md to mention the paper
- Added module docstring in dicee/trainer/model_parallelism.py citing the paper
- Updated trainer description in dicee/config.py
- Updated .github/copilot-instructions.md to reference the paper
- Updated .github/skills/run-training/SKILL.md with paper reference
- Updated .github/agents/kge-trainer.agent.md and dicee_agent.agent.md

The TP (Tensor Parallelism) trainer implements the approach described in: 'Multiple Run Ensemble Learning with Low-Dimensional Knowledge Graph Embeddings' by Demir and Ngonga Ngomo (2024, Accepted)