### PR TITLE
fix: convert user-facing asserts to explicit exceptions and migrate

### DIFF
--- a/dicee/abstracts.py
+++ b/dicee/abstracts.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 import random
 from abc import ABC
@@ -15,6 +16,8 @@ from tqdm import tqdm
 from .dataset_classes import LiteralDataset, TriplePredictionDataset
 from .models.literal import LiteralEmbeddings
 from .static_funcs import download_pretrained_model, load_json, load_model, load_model_ensemble, save_checkpoint_model
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractTrainer:
@@ -407,7 +410,7 @@ class BaseInteractiveKGE:
         assert isinstance(entity_name, str) and isinstance(embeddings, torch.FloatTensor)
 
         if entity_name in self.entity_to_idx:
-            print(f'Entity ({entity_name}) exists..')
+            logger.info(f'Entity ({entity_name}) exists..')
         else:
             self.entity_to_idx[entity_name] = len(self.entity_to_idx)
             self.idx_to_entity[self.entity_to_idx[entity_name]] = entity_name
@@ -704,7 +707,7 @@ class AbstractPPECallback(AbstractCallback):
             param_ensemble = torch.load(f"{self.path}/trainer_checkpoint_main.pt", torch.device("cpu"))
             model.load_state_dict(param_ensemble)
         else:
-            print(f"No parameter ensemble found at {self.path}/trainer_checkpoint_main.pt")
+            logger.warning(f"No parameter ensemble found at {self.path}/trainer_checkpoint_main.pt")
 
     def store_ensemble(self, param_ensemble) -> None:
         # (3) Save the updated parameter ensemble model.
@@ -730,13 +733,13 @@ class BaseInteractiveTrainKGE:
         self.set_model_train_mode()
         if optimizer is None:
             optimizer = optim.Adam(self.model.parameters(), lr=0.1)
-        print('Iteration starts...')
+        logger.info('Iteration starts...')
         # (4) Train.
         for epoch in range(iteration):
             optimizer.zero_grad()
             outputs = self.model(x)
             loss = self.model.loss(outputs, labels)
-            print(f"Iteration:{epoch}\t Loss:{loss.item()}\t Outputs:{outputs.detach().mean()}")
+            logger.info(f"Iteration:{epoch}\t Loss:{loss.item()}\t Outputs:{outputs.detach().mean()}")
             loss.backward()
             optimizer.step()
         # (5) Eval
@@ -745,7 +748,7 @@ class BaseInteractiveTrainKGE:
             x = x.to(self.model.device)
             outputs = self.model(x)
             loss = self.model.loss(outputs, labels)
-            print(f"Eval Mode:\tLoss:{loss.item()}")
+            logger.info(f"Eval Mode:\tLoss:{loss.item()}")
 
     def train_k_vs_all(self, h, r, iteration=1, lr=.001):
         """
@@ -767,19 +770,19 @@ class BaseInteractiveTrainKGE:
         # (3) Initialize optimizer # SGD considerably faster than ADAM.
         optimizer = optim.Adam(self.model.parameters(), lr=lr, weight_decay=.00001)
 
-        print('\nIteration starts.')
+        logger.info('Iteration starts.')
         # (3) Iterative training.
         for epoch in range(iteration):
             optimizer.zero_grad()
             outputs = self.model(x)
             loss = self.model.loss(outputs, labels)
             if len(idx_tails) > 0:
-                print(
+                logger.info(
                     f"Iteration:{epoch}\t"
                     f"Loss:{loss.item()}\t"
                     f"Avg. Logits for correct tails: {outputs[0, idx_tails].flatten().mean().detach()}")
             else:
-                print(
+                logger.info(
                     f"Iteration:{epoch}\t"
                     f"Loss:{loss.item()}\t"
                     f"Avg. Logits for all negatives: {outputs[0].flatten().mean().detach()}")
@@ -787,25 +790,25 @@ class BaseInteractiveTrainKGE:
             loss.backward()
             optimizer.step()
             if loss.item() < .00001:
-                print(f'loss is {loss.item():.3f}. Converged !!!')
+                logger.info(f'loss is {loss.item():.3f}. Converged !!!')
                 break
         # (4) Eval mode
         self.set_model_eval_mode()
         with torch.no_grad():
             outputs = self.model(x)
             loss = self.model.loss(outputs, labels)
-        print(f"Eval Mode:Loss:{loss.item():.4f}\t Outputs:{outputs[0, idx_tails].flatten().detach()}\n")
+        logger.info(f"Eval Mode:Loss:{loss.item():.4f}\t Outputs:{outputs[0, idx_tails].flatten().detach()}")
 
     def train(self, kg, lr=.1, epoch=10, batch_size=32, neg_sample_ratio=10, num_workers=1) -> None:
         """ Retrained a pretrain model on an input KG via negative sampling."""
         # (1) Create Negative Sampling Setting for training
-        print('Creating Dataset...')
+        logger.info('Creating Dataset...')
         train_set = TriplePredictionDataset(kg.train_set,
                                             num_entities=len(kg.entity_to_idx),
                                             num_relations=len(kg.relation_to_idx),
                                             neg_sample_ratio=neg_sample_ratio)
         num_data_point = len(train_set)
-        print('Number of data points: ', num_data_point)
+        logger.info(f'Number of data points: {num_data_point}')
         train_dataloader = DataLoader(train_set, batch_size=batch_size,
                                       #  shuffle => to have the data reshuffled at every epoc
                                       shuffle=True, num_workers=num_workers,
@@ -813,18 +816,18 @@ class BaseInteractiveTrainKGE:
 
         # (2) Go through valid triples + corrupted triples and compute scores.
         # Average loss per triple is stored. This will be used  to indicate whether we learned something.
-        print('First Eval..')
+        logger.info('First Eval..')
         self.set_model_eval_mode()
         first_avg_loss_per_triple = 0
         for x, y in train_dataloader:
             pred = self.model(x)
             first_avg_loss_per_triple += self.model.loss(pred, y)
         first_avg_loss_per_triple /= num_data_point
-        print(first_avg_loss_per_triple)
+        logger.info(first_avg_loss_per_triple)
         # (3) Prepare Model for Training
         self.set_model_train_mode()
         optimizer = optim.Adam(self.model.parameters(), lr=lr)
-        print('Training Starts...')
+        logger.info('Training Starts...')
         for epoch in range(epoch):  # loop over the dataset multiple times
             epoch_loss = 0
             for x, y in train_dataloader:
@@ -836,17 +839,17 @@ class BaseInteractiveTrainKGE:
                 epoch_loss += loss.item()
                 loss.backward()
                 optimizer.step()
-            print(f'Epoch={epoch}\t Avg. Loss per epoch: {epoch_loss / num_data_point:.3f}')
+            logger.info(f'Epoch={epoch}\t Avg. Loss per epoch: {epoch_loss / num_data_point:.3f}')
         # (5) Prepare For Saving
         self.set_model_eval_mode()
-        print('Eval starts...')
+        logger.info('Eval starts...')
         # (6) Eval model on training data to check how much an Improvement
         last_avg_loss_per_triple = 0
         for x, y in train_dataloader:
             pred = self.model(x)
             last_avg_loss_per_triple += self.model.loss(pred, y)
         last_avg_loss_per_triple /= len(train_set)
-        print(f'On average Improvement: {first_avg_loss_per_triple - last_avg_loss_per_triple:.3f}')
+        logger.info(f'On average Improvement: {first_avg_loss_per_triple - last_avg_loss_per_triple:.3f}')
 
     def train_literals(
         self,
@@ -919,7 +922,7 @@ class BaseInteractiveTrainKGE:
         loss_log = {"lit_loss": []}
         literal_model.train()
 
-        print(
+        logger.info(
             f"Training Literal Embedding model"
             f" using pre-trained '{self.model.name}' embeddings."
         )
@@ -945,9 +948,9 @@ class BaseInteractiveTrainKGE:
         self.literal_model = literal_model
         self.literal_dataset = literal_dataset
         torch.save(literal_model.state_dict(), self.path + "/literal_model.pt")
-        print(f"Literal Embedding model saved to {self.path}/literal_model.pt")
+        logger.info(f"Literal Embedding model saved to {self.path}/literal_model.pt")
         self.idx_to_data_property = {v: k for k, v in self.data_property_to_idx.items()}
         df = pd.DataFrame.from_dict(self.idx_to_data_property, orient="index", columns=["attribute"])
         df.to_csv(self.path + "/attribute_to_idx.csv")
-        print(f"Literal attributes indexing saved to {self.path}/attribute_to_idx.csv")
+        logger.info(f"Literal attributes indexing saved to {self.path}/attribute_to_idx.csv")
 

--- a/dicee/analyse_experiments.py
+++ b/dicee/analyse_experiments.py
@@ -4,9 +4,12 @@ python dicee/analyse_experiments.py --dir Experiments --features "model" "trainM
 """
 import argparse
 import json
+import logging
 import os
 
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def get_default_arguments():
@@ -159,12 +162,12 @@ def analyse(args):
     try:
         df_features = df[args.features]
     except KeyError:
-        print(f"--features ({args.features}) is not a subset of {df.columns}")
+        logger.error(f"--features ({args.features}) is not a subset of {df.columns}")
         raise KeyError
-    print(df_features.to_latex(index=False, float_format="%.3f"))
+    logger.info(df_features.to_latex(index=False, float_format="%.3f"))
     path_to_save = args.dir + '/summary.csv'
     df_features.to_csv(path_or_buf=path_to_save)
-    print(f"Saved in {path_to_save}")
+    logger.info(f"Saved in {path_to_save}")
 
 
 if __name__ == '__main__':

--- a/dicee/callbacks.py
+++ b/dicee/callbacks.py
@@ -6,6 +6,7 @@ epoch end, model saving, weight averaging, and evaluation.
 import copy
 import datetime
 import json
+import logging
 import math
 import os
 import time
@@ -23,6 +24,8 @@ import dicee.models.base_model
 from .abstracts import AbstractCallback
 from .evaluation.ensemble import evaluate_ensemble_link_prediction_performance
 from .static_funcs import save_checkpoint_model, save_pickle
+
+logger = logging.getLogger(__name__)
 
 
 class AccumulateEpochLossCallback(AbstractCallback):
@@ -58,7 +61,7 @@ class PrintCallback(AbstractCallback):
         # print(pl_module)
         # print(pl_module.summarize())
         # print(pl_module.selected_optimizer)
-        print(f"\nTraining is starting {datetime.datetime.now()}...")
+        logger.info(f"Training is starting {datetime.datetime.now()}...")
 
     def on_fit_end(self, trainer, pl_module):
         training_time = time.time() - self.start_time
@@ -70,7 +73,7 @@ class PrintCallback(AbstractCallback):
             message = f'{training_time / (60 * 60):.3f} hours.'
         else:
             message = f'{training_time:.3f} seconds.'
-        print(f"Training Runtime: {message}\n")
+        logger.info(f"Training Runtime: {message}")
 
     def on_train_batch_end(self, *args, **kwargs):
         return
@@ -117,7 +120,7 @@ class KGESaveCallback(AbstractCallback):
 
     def on_epoch_end(self, model, trainer, **kwargs):
         if self.epoch_counter % self.every_x_epoch == 0 and self.epoch_counter > 1:
-            print(f'\nStoring model {self.epoch_counter}...')
+            logger.info(f'Storing model {self.epoch_counter}...')
             save_checkpoint_model(model,
                                   path=self.path + f'/model_at_{str(self.epoch_counter)}_'
                                                    f'epoch_{str(str(datetime.datetime.now()))}.pt')
@@ -178,7 +181,7 @@ class PseudoLabellingCallback(AbstractCallback):
                 (self.data_module.train_set_idx, selected_triples.detach().numpy()),
                 axis=0)
             trainer.train_dataloader = self.data_module.train_dataloader()
-            print(f'\tEpoch:{trainer.current_epoch}: Pseudo-labelling\t |D|= {len(self.data_module.train_set_idx)}')
+            logger.info(f'Epoch:{trainer.current_epoch}: Pseudo-labelling\t |D|= {len(self.data_module.train_set_idx)}')
         model.train()
 
 
@@ -666,8 +669,8 @@ class LRScheduler(AbstractCallback):
         assert self.n_snapshots <= self.n_cycles, \
             f"n_snapshots ({self.n_snapshots}) must be less than or equal to num_cycles ({self.n_cycles})"
 
-        print(f"LRScheduler initialized with config: {config}")
-        print(f"Using: scheduler_name={self.scheduler_name}, eta_min={self.eta_min}, "
+        logger.info(f"LRScheduler initialized with config: {config}")
+        logger.info(f"Using: scheduler_name={self.scheduler_name}, eta_min={self.eta_min}, "
               f"n_cycles={self.n_cycles}, weighted_ensemble={self.weighted_ensemble}, "
               f"n_snapshots={self.n_snapshots}")
 
@@ -762,7 +765,7 @@ class LRScheduler(AbstractCallback):
         self.scheduler = LambdaLR(trainer.optimizers[0], lr_lambda=self.lr_lambda)
         self.step_count = 0
 
-        print(f"Using learning rate scheduler: {self.scheduler_name}")
+        logger.info(f"Using learning rate scheduler: {self.scheduler_name}")
 
     def on_train_batch_end(self, trainer, model, outputs, batch, batch_idx):
         """Step the LR scheduler and save model snapshot if needed after each batch."""
@@ -852,4 +855,4 @@ class LRScheduler(AbstractCallback):
         # Write the dictionary to the JSON file
         with open(ensemble_eval_report_path, 'w', encoding='utf-8') as f:
             json.dump(self.ensemble_eval_report, f, indent=4, ensure_ascii=False)
-        print(f"Ensemble Evaluations: Evaluate {model.name} on Test Set with an ensemble of {len(self.model_snapshots)} models: \n{ensemble_eval_report}")
+        logger.info(f"Ensemble Evaluations: Evaluate {model.name} on Test Set with an ensemble of {len(self.model_snapshots)} models: \n{ensemble_eval_report}")

--- a/dicee/dataset_classes/_factory.py
+++ b/dicee/dataset_classes/_factory.py
@@ -5,6 +5,7 @@ select the appropriate ``torch.utils.data.Dataset`` sub-class based on the
 requested scoring technique and labelling strategy.
 """
 
+import logging
 from typing import Union
 
 import numpy as np
@@ -18,6 +19,8 @@ from ._bpe import (
 )
 from ._label_based import AllvsAll, FSDP1vsSampleDataset, KvsAll, KvsSampleDataset, OnevsAllDataset
 from ._negative_sampling import FixedNegSampleDataset, OnevsSample, TriplePredictionDataset
+
+logger = logging.getLogger(__name__)
 
 
 @timeit
@@ -195,5 +198,5 @@ def construct_dataset(
     else:
         raise KeyError("Illegal input.")
 
-    print(f"Number of datapoints: {len(train_set)}")
+    logger.info(f"Number of datapoints: {len(train_set)}")
     return train_set

--- a/dicee/dataset_classes/_label_based.py
+++ b/dicee/dataset_classes/_label_based.py
@@ -5,10 +5,14 @@ Provides ``KvsAll``, ``AllvsAll``, ``KvsSampleDataset``, and
 pair and the target is a label vector over all entities (or relations).
 """
 
+import logging
+
 import numpy as np
 import torch
 
 from ..static_preprocess_funcs import mapping_from_first_two_cols_to_third
+
+logger = logging.getLogger(__name__)
 
 
 class OnevsAllDataset(torch.utils.data.Dataset):
@@ -112,7 +116,7 @@ class KvsAll(torch.utils.data.Dataset):
             try:
                 assert isinstance(self.train_target[0], np.ndarray)
             except (IndexError, AssertionError):
-                print(self.train_target)
+                logger.error(self.train_target)
                 exit(1)
         else:
             self.train_target = list(store.values())
@@ -169,12 +173,12 @@ class AllvsAll(torch.utils.data.Dataset):
         self.target_dim = len(entity_idxs)
         # mapping_from_first_two_cols_to_third already returns sorted dict
         store = mapping_from_first_two_cols_to_third(train_set_idx)
-        print("Number of unique pairs:", len(store))
+        logger.info(f"Number of unique pairs: {len(store)}")
         for i in range(len(entity_idxs)):
             for j in range(len(relation_idxs)):
                 if store.get((i, j), None) is None:
                     store[(i, j)] = list()
-        print("Number of unique augmented pairs:", len(store))
+        logger.info(f"Number of unique augmented pairs: {len(store)}")
         # Re-sort after adding new keys to maintain consistent ordering
         store = dict(sorted(store.items()))
         assert len(store) > 0

--- a/dicee/dataset_classes/_literal.py
+++ b/dicee/dataset_classes/_literal.py
@@ -4,12 +4,15 @@ Provides ``LiteralDataset`` for training models on numeric literal triples
 (entity, data-property, value).
 """
 
+import logging
 import os
 
 import numpy as np
 import pandas as pd
 import torch
 from torch.utils.data import Dataset
+
+logger = logging.getLogger(__name__)
 
 
 class LiteralDataset(Dataset):
@@ -83,7 +86,7 @@ class LiteralDataset(Dataset):
                     )
                     .reset_index(drop=True)
                 )
-                print(
+                logger.info(
                     f"Training Literal Embedding model with "
                     f"{self.sampling_ratio * 100:.1f}% of the train set."
                 )
@@ -125,7 +128,7 @@ class LiteralDataset(Dataset):
             self.normalization_params["type"] = "min-max"
 
         else:
-            print(" No normalization applied.")
+            logger.info("No normalization applied.")
             df["value_norm"] = df["value"]
             if self.normalization_type is None:
                 self.normalization_params = {}

--- a/dicee/evaluation/evaluator.py
+++ b/dicee/evaluation/evaluator.py
@@ -6,6 +6,7 @@ scoring techniques.
 """
 
 import json
+import logging
 import os
 import pickle
 from typing import Dict, List, Optional, Tuple
@@ -21,6 +22,8 @@ from .utils import (
     create_hits_dict,
     update_hits,
 )
+
+logger = logging.getLogger(__name__)
 
 # Valid scoring techniques
 VALID_SCORING_TECHNIQUES = frozenset([
@@ -141,7 +144,7 @@ class Evaluator:
             return None
 
         if isinstance(self.args.eval_model, bool):
-            print('Wrong input:RESET')
+            logger.warning('Wrong input:RESET')
             self.args.eval_model = 'train_val_test'
 
         # Route to appropriate evaluation method based on scoring technique
@@ -416,7 +419,7 @@ class Evaluator:
         hits = create_hits_dict(hits_range)
 
         if info and not self.during_training:
-            print(info + ':', end=' ')
+            logger.info(f"{info}:")
 
         if form_of_labelling == 'RelationPrediction':
             ranks, hits = self._evaluate_relation_prediction(
@@ -432,8 +435,8 @@ class Evaluator:
         results = compute_metrics_from_ranks_simple(ranks, num_triples, hits)
 
         if info and not self.during_training:
-            print(info)
-            print(results)
+            logger.info(info)
+            logger.info(results)
 
         return results
 
@@ -533,20 +536,20 @@ class Evaluator:
         enc = tiktoken.get_encoding("gpt2")
 
         if info and not self.during_training:
-            print(info + ':', end=' ')
+            logger.info(f"{info}:")
 
         for i in range(0, num_triples, self.args.batch_size):
             str_data_batch = triples[i:i + self.args.batch_size]
             for triple in str_data_batch:
                 s, p, o = triple
                 x = torch.LongTensor([enc.encode(s + " " + p)])
-                print("Triple:", triple, end="\t")
+                logger.info(f"Triple: {triple}")
                 y = model.generate(
                     x, max_new_tokens=100,
                     temperature=model.temperature,
                     top_k=model.topk
                 ).tolist()
-                print("Generated:", enc.decode(y[0]))
+                logger.info(f"Generated: {enc.decode(y[0])}")
 
         return {'H@1': -1, 'H@3': -1, 'H@10': -1, 'MRR': -1}
 
@@ -576,7 +579,7 @@ class Evaluator:
         hits = create_hits_dict(hits_range)
 
         if info and not self.during_training:
-            print(info + ':', end=' ')
+            logger.info(f"{info}:")
 
         for i in range(0, num_triples, self.args.batch_size):
             str_data_batch = triples[i:i + self.args.batch_size]
@@ -614,8 +617,8 @@ class Evaluator:
         results = compute_metrics_from_ranks_simple(ranks, num_triples, hits)
 
         if info and not self.during_training:
-            print(info)
-            print(results)
+            logger.info(info)
+            logger.info(results)
 
         return results
 

--- a/dicee/evaluation/link_prediction.py
+++ b/dicee/evaluation/link_prediction.py
@@ -4,6 +4,7 @@ This module provides various functions for evaluating link prediction
 performance of knowledge graph embedding models.
 """
 
+import logging
 from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -22,6 +23,8 @@ from .utils import (
     create_hits_dict,
     update_hits,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @torch.no_grad()
@@ -336,8 +339,8 @@ def evaluate_lp(
     assert re_vocab is not None, "re_vocab must be provided"
 
     model.eval()
-    print(info)
-    print(f'Num of triples {len(triple_idx)}')
+    logger.info(info)
+    logger.info(f'Num of triples {len(triple_idx)}')
 
     hits = {}
     reciprocal_ranks = []
@@ -406,7 +409,7 @@ def evaluate_lp(
         scale_factor=2
     ) | {'MRR': sum(reciprocal_ranks) / (float(len(triple_idx) * 2))}
 
-    print(results)
+    logger.info(results)
     return results
 
 
@@ -437,8 +440,8 @@ def evaluate_bpe_lp(
     assert len(triple_idx[0]) == 3
 
     model.eval()
-    print(info)
-    print(f'Num of triples {len(triple_idx)}')
+    logger.info(info)
+    logger.info(f'Num of triples {len(triple_idx)}')
 
     hits = {}
     reciprocal_ranks = []
@@ -490,7 +493,7 @@ def evaluate_bpe_lp(
         scale_factor=2
     ) | {'MRR': sum(reciprocal_ranks) / (float(len(triple_idx) * 2))}
 
-    print(results)
+    logger.info(results)
     return results
 
 

--- a/dicee/evaluation/literal_prediction.py
+++ b/dicee/evaluation/literal_prediction.py
@@ -4,10 +4,13 @@ This module provides functions for evaluating literal/attribute prediction
 performance of knowledge graph embedding models.
 """
 
+import logging
 import os
 from typing import Optional
 
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def evaluate_literal_prediction(
@@ -87,7 +90,7 @@ def evaluate_literal_prediction(
         prediction_df = test_df[["head", "attribute", "predictions"]]
         prediction_path = os.path.join(kge_model.path, "lit_predictions.csv")
         prediction_df.to_csv(prediction_path, index=False)
-        print(f"Literal predictions saved to {prediction_path}")
+        logger.info(f"Literal predictions saved to {prediction_path}")
     try:
         from sklearn.metrics import mean_absolute_error, root_mean_squared_error
     except ImportError:
@@ -107,12 +110,12 @@ def evaluate_literal_prediction(
         ).reset_index()
 
         pd.options.display.float_format = "{:.6f}".format
-        print("Literal-Prediction evaluation results on Test Set")
-        print(attr_error_metrics)
+        logger.info("Literal-Prediction evaluation results on Test Set")
+        logger.info(attr_error_metrics)
 
         results_path = os.path.join(kge_model.path, "lit_eval_results.csv")
         attr_error_metrics.to_csv(results_path, index=False)
-        print(f"Literal-Prediction evaluation results saved to {results_path}")
+        logger.info(f"Literal-Prediction evaluation results saved to {results_path}")
 
         if return_attr_error_metrics:
             return attr_error_metrics

--- a/dicee/executer.py
+++ b/dicee/executer.py
@@ -36,6 +36,9 @@ logging.getLogger('lightning').setLevel(logging.WARNING)
 warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 os.environ["TORCH_DISTRIBUTED_DEBUG"] = "INFO"
 
+logger = logging.getLogger(__name__)
+
+
 class Execute:
     """Executor class for training, retraining and evaluating KGE models.
 
@@ -136,11 +139,11 @@ class Execute:
 
         if os.path.exists(path):
             if not reuse_existing:
-                print(f"Deleting existing directory: {path}")
+                logger.info(f"Deleting existing directory: {path}")
                 shutil.rmtree(path)
                 os.makedirs(path, exist_ok=False)
             else:
-                print(f"Reusing existing directory: {path}")
+                logger.info(f"Reusing existing directory: {path}")
         else:
             os.makedirs(path, exist_ok=False)
 
@@ -163,10 +166,10 @@ class Execute:
         )
 
         if os.path.exists(memmap_path) and os.path.exists(details_path):
-            print("KG already exists, skipping creation.")
+            logger.info("KG already exists, skipping creation.")
             return
 
-        print("Creating knowledge graph...")
+        logger.info("Creating knowledge graph...")
         self.knowledge_graph = read_or_load_kg(self.args, cls=KG)
         self._update_args_from_kg()
         self._save_kg_memmap(memmap_path, details_path)
@@ -260,7 +263,7 @@ class Execute:
         None
 
         """
-        print('*** Save Trained Model ***')
+        logger.info('*** Save Trained Model ***')
         self.trained_model.eval()
         self.trained_model.to('cpu')
         # Save the epoch loss
@@ -319,7 +322,7 @@ class Execute:
         # @TODO: Move to static funcs
         # Report total runtime.
         self.report['Runtime'] = time.time() - self.start_time
-        print(f"Total Runtime: {self.report['Runtime']:.3f} seconds")
+        logger.info(f"Total Runtime: {self.report['Runtime']:.3f} seconds")
         with open(self.args.full_storage_path + '/report.json', 'w') as file_descriptor:
             json.dump(self.report, file_descriptor, indent=4)
 
@@ -342,7 +345,7 @@ class Execute:
         """
         try:
             self.start_time = time.time()
-            print(f"Start time:{datetime.datetime.now()}")
+            logger.info(f"Start time:{datetime.datetime.now()}")
             # (1) Create knowledge graph
             self.create_and_store_kg()
             # (2) Synchronize processes if distributed training is used
@@ -393,16 +396,16 @@ class ContinuousExecute(Execute):
         previous_args["num_epochs"]=args["num_epochs"]
         previous_args["continual_learning"]=args["continual_learning"]
         previous_args["path_experiment_folder"]=args["continual_learning"]
-        print("Updated configuration:",previous_args)
+        logger.info(f"Updated configuration: {previous_args}")
         try:
             report = load_json(args['continual_learning'] + '/report.json')
             previous_args['num_entities'] = report['num_entities']
             previous_args['num_relations'] = report['num_relations']
         except AssertionError:
-            print("Couldn't find report.json.")
+            logger.warning("Couldn't find report.json.")
         previous_args = SimpleNamespace(**previous_args)
-        print('ContinuousExecute starting...')
-        print(previous_args)
+        logger.info('ContinuousExecute starting...')
+        logger.info(previous_args)
         super().__init__(previous_args, continuous_training=True)
 
     def continual_start(self) -> dict:

--- a/dicee/knowledge_graph_embeddings.py
+++ b/dicee/knowledge_graph_embeddings.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import traceback
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
@@ -8,6 +9,8 @@ import torch
 from .abstracts import BaseInteractiveKGE, BaseInteractiveTrainKGE, InteractiveQueryDecomposition
 from .evaluation.link_prediction import evaluate_lp
 from .static_funcs import load_pickle
+
+logger = logging.getLogger(__name__)
 
 
 class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrainKGE):
@@ -27,7 +30,8 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
         return "KGE | " + str(self.model)
 
     def to(self, device: str) -> None:
-        assert "cpu" in device or "cuda" in device, "Device must be either cpu or cuda"
+        if "cpu" not in device and "cuda" not in device:
+            raise ValueError(f"Device must be either cpu or cuda, got {device!r}")
         self.model.to(device)
 
     def get_transductive_entity_embeddings(self,
@@ -39,7 +43,8 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
         if isinstance(indices, torch.LongTensor):
             """ Do nothing"""
         else:
-            assert isinstance(indices, list), f"indices must be either torch.LongTensor or list of strings{indices}"
+            if not isinstance(indices, list):
+                raise TypeError(f"indices must be either torch.LongTensor or list of strings, got {indices}")
             indices = torch.LongTensor([self.entity_to_idx[i] for i in indices])
 
         if as_pytorch:
@@ -54,13 +59,14 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
     def create_vector_database(self, collection_name: str, distance: str,
                                location: str = "localhost",
                                port: int = 6333):
-        assert distance in ["cosine", "dot"]
+        if distance not in ["cosine", "dot"]:
+            raise ValueError(f"distance must be one of ['cosine', 'dot'], got {distance!r}")
         # lazy imports
         try:
             from qdrant_client import QdrantClient
         except ModuleNotFoundError:
             traceback.print_exc()
-            print("Please install qdrant_client: pip install qdrant_client")
+            logger.error("Please install qdrant_client: pip install qdrant_client")
             exit(1)
 
         from qdrant_client.http.models import Distance, PointStruct, VectorParams
@@ -69,27 +75,28 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
         client = QdrantClient(location=location, port=port)
         # If the collection is not created, create it
         if collection_name in [i.name for i in client.get_collections().collections]:
-            print("Deleting existing collection ", collection_name)
+            logger.info(f"Deleting existing collection {collection_name}")
             client.delete_collection(collection_name=collection_name)
 
-        print(f"Creating a collection {collection_name} with distance metric:Cosine")
+        logger.info(f"Creating a collection {collection_name} with distance metric:Cosine")
         client.create_collection(collection_name=collection_name,
                                  vectors_config=VectorParams(size=self.model.embedding_dim, distance=Distance.COSINE))
 
         entities = list(self.idx_to_entity.values())
-        print("Fetching entity embeddings..")
+        logger.info("Fetching entity embeddings..")
         vectors = self.get_transductive_entity_embeddings(indices=entities, as_list=True)
-        print("Indexing....")
+        logger.info("Indexing....")
         points = []
         for str_ent, vec in zip(entities, vectors):
             points.append(PointStruct(id=self.entity_to_idx[str_ent],
                                       vector=vec, payload={"name": str_ent}))
         operation_info = client.upsert(collection_name=collection_name, wait=True,
                                        points=points)
-        print(operation_info)
+        logger.info(operation_info)
 
     def generate(self, h="", r=""):
-        assert self.configs["byte_pair_encoding"]
+        if not self.configs["byte_pair_encoding"]:
+            raise ValueError("generate() requires a model trained with byte_pair_encoding=True")
 
         h_encode = self.enc.encode(h)
         r_encode = self.enc.encode(r)
@@ -123,11 +130,12 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
             X[:, pointer] = id_next_token
             pointer += 1
             counter += 1
-            print(self.enc.decode(tokens), end=f"\t {score}\n")
+            logger.info(f"{self.enc.decode(tokens)}\t {score}")
 
     # given a string, return is bpe encoded embeddings
     def eval_lp_performance(self, dataset=List[Tuple[str, str, str]], filtered=True):
-        assert isinstance(dataset, list) and len(dataset) > 0
+        if not isinstance(dataset, list) or len(dataset) == 0:
+            raise TypeError("dataset must be a non-empty list of (head, relation, tail) triples")
         idx_dataset = np.array(
             [(self.entity_to_idx[s], self.relation_to_idx[p], self.entity_to_idx[o]) for s, p, o in dataset])
         if filtered:
@@ -435,7 +443,8 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
             - Missing element: vector of all possible scores
 
         Raises:
-            AssertionError: If inputs are not strings or lists of strings.
+            TypeError: If inputs are not strings or lists of strings.
+            ValueError: If a required argument for the query type is missing.
 
         Examples:
             >>> # Score a specific triple
@@ -448,31 +457,37 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
         """
         # (1) Sanity checking.
         if h is not None:
-            assert isinstance(h, list) or isinstance(h, str)
-            assert isinstance(h[0], str)
+            if not isinstance(h, (list, str)):
+                raise TypeError(f"h must be a str or list of str, got {type(h)}")
+            if not isinstance(h[0], str):
+                raise TypeError(f"h must contain str entities, got {type(h[0])}")
         if r is not None:
-            assert isinstance(r, list) or isinstance(r, str)
-            assert isinstance(r[0], str)
+            if not isinstance(r, (list, str)):
+                raise TypeError(f"r must be a str or list of str, got {type(r)}")
+            if not isinstance(r[0], str):
+                raise TypeError(f"r must contain str relations, got {type(r[0])}")
         if t is not None:
-            assert isinstance(t, list) or isinstance(t, str)
-            assert isinstance(t[0], str)
+            if not isinstance(t, (list, str)):
+                raise TypeError(f"t must be a str or list of str, got {type(t)}")
+            if not isinstance(t[0], str):
+                raise TypeError(f"t must contain str entities, got {type(t[0])}")
 
         # (2) Predict missing head entity given a relation and a tail entity.
         if h is None:
-            assert r is not None
-            assert t is not None
+            if r is None or t is None:
+                raise ValueError("r and t must both be provided when predicting a missing head entity")
             # ? r, t
             scores = self.predict_missing_head_entity(r, t, within, batch_size=2, topk=len(self.entity_to_idx), return_indices=False)
         # (3) Predict missing relation given a head entity and a tail entity.
         elif r is None:
-            assert h is not None
-            assert t is not None
+            if h is None or t is None:
+                raise ValueError("h and t must both be provided when predicting a missing relation")
             # h ? t
             scores = self.predict_missing_relations(h, t, within, batch_size=2, topk=len(self.relation_to_idx), return_indices=False)
         # (4) Predict missing tail entity given a head entity and a relation
         elif t is None:
-            assert h is not None
-            assert r is not None
+            if h is None or r is None:
+                raise ValueError("h and r must both be provided when predicting a missing tail entity")
             # h r ?
             scores = self.predict_missing_tail_entity(h, r, within, batch_size=2, topk=len(self.entity_to_idx), return_indices=False)
         else:
@@ -509,8 +524,8 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
             For batch query: List of such lists, one per query.
 
         Raises:
-            AssertionError: If more than one of h, r, t is None.
-            AssertionError: If the required arguments for a query type are None.
+            TypeError: If h, r, or t is not a str or list of str.
+            ValueError: If the required arguments for a query type are None.
 
         Examples:
             >>> model.predict_topk(h=["Mongolia"], r=["isLocatedIn"], topk=3)
@@ -521,16 +536,17 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
         """
 
         # (1) Sanity checking
-        if h is not None:
-            assert isinstance(h, (list, str))
-        if r is not None:
-            assert isinstance(r, (list, str))
-        if t is not None:
-            assert isinstance(t, (list, str))
+        if h is not None and not isinstance(h, (list, str)):
+            raise TypeError(f"h must be a str or list of str, got {type(h)}")
+        if r is not None and not isinstance(r, (list, str)):
+            raise TypeError(f"r must be a str or list of str, got {type(r)}")
+        if t is not None and not isinstance(t, (list, str)):
+            raise TypeError(f"t must be a str or list of str, got {type(t)}")
 
         # --- Missing HEAD: (?, r, t) ---
         if h is None:
-            assert r is not None and t is not None
+            if r is None or t is None:
+                raise ValueError("r and t must both be provided when predicting a missing head entity")
             # Convert input to lists if they're strings
             if isinstance(r, str):
                 r = [r]
@@ -556,7 +572,8 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
 
         # --- Missing RELATION: (h, ?, t) ---
         elif r is None:
-            assert h is not None and t is not None
+            if h is None or t is None:
+                raise ValueError("h and t must both be provided when predicting a missing relation")
             flat_scores, flat_indices = self.predict_missing_relations(h, t, within, batch_size, topk, return_indices=True)
 
             # Convert input to lists if they're strings
@@ -584,7 +601,8 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
 
         # --- Missing TAIL: (h, r, ?) ---
         elif t is None:
-            assert h is not None and r is not None
+            if h is None or r is None:
+                raise ValueError("h and r must both be provided when predicting a missing tail entity")
 
             # predict_missing_tail_entity now returns both scores and indices
             flat_scores, flat_indices = self.predict_missing_tail_entity(h, r, within, batch_size, topk, return_indices=True)
@@ -782,16 +800,18 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
         """
 
         if queries is not None:
+            if query is not None:
+                raise ValueError("Provide either 'query' or 'queries', not both")
             results = []
             for i in queries:
-                assert query is None
                 results.append(
                     self.answer_multi_hop_query(query_type=query_type, query=i, tnorm=tnorm, neg_norm=neg_norm,
                                                 lambda_=lambda_, k=k, only_scores=only_scores,
                                                 use_logits=use_logits))
             return results
 
-        assert len(self.entity_to_idx) >= k >= 0
+        if not (len(self.entity_to_idx) >= k >= 0):
+            raise ValueError(f"k must satisfy 0 <= k <= {len(self.entity_to_idx)}, got {k}")
 
         query_name_dict = {
             ("e", ("r",)): "1p",
@@ -1290,8 +1310,10 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
         {(e,r,x) | f(e,r,x) > confidence \\land (e,r,x) \not\\in G
         """
 
-        assert 1.0 >= confidence >= 0.0
-        assert topk >= 1
+        if not (1.0 >= confidence >= 0.0):
+            raise ValueError(f"confidence must be in [0.0, 1.0], got {confidence}")
+        if topk < 1:
+            raise ValueError(f"topk must be >= 1, got {topk}")
 
         def select(items: List[str], item_mapping: Dict[str, int]) -> Iterable[Tuple[str, int]]:
             """
@@ -1315,11 +1337,11 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
                 return ((i, item_mapping[i]) for i in items)
 
         extended_triples = set()
-        print(f'Number of entities:{len(self.entity_to_idx)} \t Number of relations:{len(self.relation_to_idx)}')
+        logger.info(f'Number of entities:{len(self.entity_to_idx)} \t Number of relations:{len(self.relation_to_idx)}')
 
         # (5) Cartesian Product over entities and relations
         # (5.1) Iterate over entities
-        print('Finding missing triples..')
+        logger.info('Finding missing triples..')
         for str_head_entity, idx_entity in select(entities, self.entity_to_idx):
             # (5.1) Iterate over relations
             for str_relation, idx_relation in select(relations, self.relation_to_idx):
@@ -1334,7 +1356,7 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
                     else:
                         # (5.8) Remember it
                         extended_triples.add((str_head_entity, str_relation, str_entity))
-                        print(f'Number of found missing triples: {len(extended_triples)}')
+                        logger.info(f'Number of found missing triples: {len(extended_triples)}')
                         if len(extended_triples) == at_most:
                             return extended_triples
                         # No need to store a large KG into memory
@@ -1348,7 +1370,7 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
                         else:
                             # (5.8) Remember it
                             extended_triples.add((str_head_entity, str_relation, str_entity))
-                            print(f'Number of found missing triples: {len(extended_triples)}')
+                            logger.info(f'Number of found missing triples: {len(extended_triples)}')
                             if len(extended_triples) == at_most:
                                 return extended_triples
         return extended_triples
@@ -1387,13 +1409,14 @@ class KGE(BaseInteractiveKGE, InteractiveQueryDecomposition, BaseInteractiveTrai
             attribute = [attribute]
 
         # Validate that entity and attribute are lists of strings
-        assert isinstance(entity, list)
-        assert isinstance(attribute, list)
-        assert all(isinstance(e, str) for e in entity)      # Ensure all elements in entity are strings
-        assert all(isinstance(a, str) for a in attribute)   # Ensure all elements in attribute are strings
+        if not isinstance(entity, list) or not all(isinstance(e, str) for e in entity):
+            raise TypeError(f"entity must be a str or list of str, got {entity}")
+        if not isinstance(attribute, list) or not all(isinstance(a, str) for a in attribute):
+            raise TypeError(f"attribute must be a str or list of str, got {attribute}")
 
         # Ensure entity and attribute lists are the same length
-        assert len(entity) == len(attribute), "Entity and attribute lists must be of equal length"
+        if len(entity) != len(attribute):
+            raise ValueError("Entity and attribute lists must be of equal length")
 
         # Convert entity and attribute names to their corresponding index tensor
         entity_idx = torch.LongTensor([self.entity_to_idx[i] for i in entity])

--- a/dicee/models/base_model.py
+++ b/dicee/models/base_model.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, List, Tuple, Union
 
 import lightning as pl
@@ -7,6 +8,8 @@ from torch import nn
 from torch.nn import functional as F
 
 from .adopt import ADOPT
+
+logger = logging.getLogger(__name__)
 
 
 class BaseKGELightning(pl.LightningModule):
@@ -176,7 +179,7 @@ class BaseKGELightning(pl.LightningModule):
                                                        weight_decay=self.weight_decay)
         else:
             raise KeyError(f"{self.optimizer_name} is not found!")
-        print(self.selected_optimizer)
+        logger.info(self.selected_optimizer)
         return self.selected_optimizer
 
 
@@ -411,7 +414,7 @@ class BaseKGE(BaseKGELightning):
         elif self.args['init_param'] == 'xavier_normal':
             self.param_init = torch.nn.init.xavier_normal_
         else:
-            print(f'--init_param (***{self.args.get("init_param")}***) not found')
+            logger.warning(f'--init_param (***{self.args.get("init_param")}***) not found')
             self.optimizer_name = IdentityClass
 
     def forward(self, x: Union[torch.LongTensor, Tuple[torch.LongTensor, torch.LongTensor]],

--- a/dicee/models/clifford.py
+++ b/dicee/models/clifford.py
@@ -1,6 +1,10 @@
+import logging
+
 import torch
 
 from .base_model import BaseKGE
+
+logger = logging.getLogger(__name__)
 
 
 class Keci(BaseKGE):
@@ -845,7 +849,7 @@ class CKeci(Keci):
         super().__init__(args)
         self.name = 'CKeci'
         self.requires_grad_for_interactions = False
-        print(f'r:{self.r}\t p:{self.p}\t q:{self.q}')
+        logger.info(f'r:{self.r}\t p:{self.p}\t q:{self.q}')
         if self.p > 0:
             self.p_coefficients = torch.nn.Embedding(num_embeddings=1, embedding_dim=self.p,_freeze=self.requires_grad_for_interactions)
             torch.nn.init.ones_(self.p_coefficients.weight)

--- a/dicee/models/function_space.py
+++ b/dicee/models/function_space.py
@@ -1,7 +1,11 @@
+import logging
+
 import numpy as np
 import torch
 
 from .base_model import BaseKGE
+
+logger = logging.getLogger(__name__)
 
 
 class FMult(BaseKGE):
@@ -143,7 +147,7 @@ class FMult2(BaseKGE):
             self.embedding_dim += 1
             tuned_embedding_dim = True
         if tuned_embedding_dim:
-            print(f"\n\n*****Embedding dimension reset to {self.embedding_dim} to fit model architecture!*****\n")
+            logger.warning(f"Embedding dimension reset to {self.embedding_dim} to fit model architecture!")
         self.k = int(np.sqrt((self.embedding_dim - 1) // self.n_layers))
         self.n = 50
         self.a, self.b = -1.0, 1.0

--- a/dicee/models/pykeen_models.py
+++ b/dicee/models/pykeen_models.py
@@ -1,3 +1,4 @@
+import logging
 import traceback
 from collections import namedtuple
 
@@ -5,6 +6,8 @@ import torch
 import torch.utils.data
 
 from .base_model import BaseKGE
+
+logger = logging.getLogger(__name__)
 
 
 class PykeenKGE(BaseKGE):
@@ -71,14 +74,14 @@ class PykeenKGE(BaseKGE):
             #TransR does not support a 'regularizer'
             pass
         else:
-            print("Pykeen model have a memory leak caused by their implementation of regularizers")
-            print(f"{self.name} does not seem to have any regularizer")
+            logger.warning("Pykeen model have a memory leak caused by their implementation of regularizers")
+            logger.warning(f"{self.name} does not seem to have any regularizer")
         try:
             # lazy import
             from pykeen.models import model_resolver
         except ImportError:
-            print(traceback.format_exc())
-            print("Pykeen does not work with pytorch>2.0.0. Current pytorch version:",torch.__version__)
+            logger.error(traceback.format_exc())
+            logger.error(f"Pykeen does not work with pytorch>2.0.0. Current pytorch version:{torch.__version__}")
             exit(1)
         self.model = model_resolver. \
             make(self.name, self.model_kwargs, triples_factory=

--- a/dicee/models/transformers.py
+++ b/dicee/models/transformers.py
@@ -7,6 +7,7 @@ https://github.com/openai/gpt-2/blob/master/src/model.py
 https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt2/modeling_gpt2.py
 """
 import inspect
+import logging
 import math
 from dataclasses import dataclass
 
@@ -15,6 +16,8 @@ import torch.nn as nn
 from torch.nn import functional as F
 
 from .base_model import BaseKGE
+
+logger = logging.getLogger(__name__)
 
 
 class BytE(BaseKGE):
@@ -148,7 +151,7 @@ class SelfAttention(nn.Module):
         # flash attention make GPU go brrrrr but support is only in PyTorch >= 2.0
         self.flash = hasattr(torch.nn.functional, 'scaled_dot_product_attention')
         if not self.flash:
-            print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
+            logger.warning("using slow attention. Flash Attention requires PyTorch >= 2.0")
             # causal mask to ensure that attention is only applied to the left in the input sequence
             self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
                                  .view(1, 1, config.block_size, config.block_size))
@@ -257,7 +260,7 @@ class GPT(nn.Module):
                 torch.nn.init.normal_(p, mean=0.0, std=0.02 / math.sqrt(2 * config.n_layer))
 
         # report number of parameters
-        print("number of parameters: %.2fM" % (self.get_num_params() / 1e6,))
+        logger.info("number of parameters: %.2fM" % (self.get_num_params() / 1e6,))
 
     def get_num_params(self, non_embedding=True):
         """
@@ -325,7 +328,7 @@ class GPT(nn.Module):
         # only dropout can be overridden see more notes below
         assert all(k == 'dropout' for k in override_args)
         from transformers import GPT2LMHeadModel
-        print("loading weights from pretrained gpt: %s" % model_type)
+        logger.info("loading weights from pretrained gpt: %s" % model_type)
 
         # n_layer, n_head and n_embd are determined from model_type
         config_args = {
@@ -334,13 +337,13 @@ class GPT(nn.Module):
             'gpt2-large': dict(n_layer=36, n_head=20, n_embd=1280),  # 774M params
             'gpt2-xl': dict(n_layer=48, n_head=25, n_embd=1600),  # 1558M params
         }[model_type]
-        print("forcing vocab_size=50257, block_size=1024, bias=True")
+        logger.info("forcing vocab_size=50257, block_size=1024, bias=True")
         config_args['vocab_size'] = 50257  # always 50257 for GPT model checkpoints
         config_args['block_size'] = 1024  # always 1024 for GPT model checkpoints
         config_args['bias'] = True  # always True for GPT model checkpoints
         # we can override the dropout rate, if desired
         if 'dropout' in override_args:
-            print(f"overriding dropout rate to {override_args['dropout']}")
+            logger.info(f"overriding dropout rate to {override_args['dropout']}")
             config_args['dropout'] = override_args['dropout']
         # create a from-scratch initialized minGPT model
         config = GPTConfig(**config_args)
@@ -390,14 +393,14 @@ class GPT(nn.Module):
         ]
         num_decay_params = sum(p.numel() for p in decay_params)
         num_nodecay_params = sum(p.numel() for p in nodecay_params)
-        print(f"num decayed parameter tensors: {len(decay_params)}, with {num_decay_params:,} parameters")
-        print(f"num non-decayed parameter tensors: {len(nodecay_params)}, with {num_nodecay_params:,} parameters")
+        logger.info(f"num decayed parameter tensors: {len(decay_params)}, with {num_decay_params:,} parameters")
+        logger.info(f"num non-decayed parameter tensors: {len(nodecay_params)}, with {num_nodecay_params:,} parameters")
         # Create AdamW optimizer and use the fused version if it is available
         fused_available = 'fused' in inspect.signature(torch.optim.AdamW).parameters
         use_fused = fused_available and device_type == 'cuda'
         extra_args = dict(fused=True) if use_fused else dict()
         optimizer = torch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas, **extra_args)
-        print(f"using fused AdamW: {use_fused}")
+        logger.info(f"using fused AdamW: {use_fused}")
 
         return optimizer
 

--- a/dicee/query_generator.py
+++ b/dicee/query_generator.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pickle
 import random
@@ -8,6 +9,8 @@ from typing import Dict, List, Tuple, Union
 import numpy as np
 
 from .static_funcs import load_pickle, save_pickle
+
+logger = logging.getLogger(__name__)
 
 
 class QueryGenerator:
@@ -250,7 +253,7 @@ class QueryGenerator:
 
             if max(len(answer_set - small_answer_set), len(small_answer_set - answer_set)) > self.max_ans_num:
                 num_more_answer += 1
-                print(num_more_answer)
+                logger.info(num_more_answer)
                 continue
 
             if self.list2tuple(query) in queries[self.list2tuple(query_structure)]:
@@ -468,7 +471,7 @@ class QueryGenerator:
         # @TODO: test_queries has keys that are tuple ,e.g. ('e', ('r',))
         # Yet, query structure defined as a list ['e', ['r']].
         # Fix this inconsistency
-        print(
+        logger.info(
             f"General structure is {query_struct} with name {query_type}. Number of queries generated: {len(test_tp_answers)}")
         return test_queries, test_tp_answers, test_fp_answers, test_fn_answers
 
@@ -481,7 +484,7 @@ class QueryGenerator:
         try:
             gen_id = self.query_names.index(query_type)
         except ValueError:
-            print(f"Invalid query_type: {query_type}")
+            logger.warning(f"Invalid query_type: {query_type}")
             return []
         queries, tp_answers, fp_answers, fn_answers = self.generate_queries(self.query_structures[gen_id:gen_id + 1],
                                                                             gen_num, query_type)
@@ -522,7 +525,7 @@ class QueryGenerator:
     @staticmethod
     def load_queries_and_answers(path: str) -> List[Tuple[str, Tuple[defaultdict]]]:
         """ Load Queries from Disk to Memory"""
-        print("Loading...")
+        logger.info("Loading...")
         data = load_pickle(file_path=path)
         assert isinstance(data, list)
         assert isinstance(data[0], tuple)

--- a/dicee/read_preprocess_save_load_kg/preprocess.py
+++ b/dicee/read_preprocess_save_load_kg/preprocess.py
@@ -1,4 +1,5 @@
 import concurrent
+import logging
 from typing import List, Tuple, Union
 
 import numpy as np
@@ -8,6 +9,8 @@ import polars as pl
 from dicee.static_funcs import numpy_data_type_changer
 
 from .util import apply_reciprocal_or_noise, dataset_sanity_checking, get_ee_vocab, get_er_vocab, get_re_vocab, pandas_dataframe_indexer, polars_dataframe_indexer, timeit
+
+logger = logging.getLogger(__name__)
 
 
 class PreprocessKG:
@@ -52,21 +55,23 @@ class PreprocessKG:
                     data = np.concatenate([self.kg.train_set, self.kg.valid_set, self.kg.test_set])
                 else:
                     data = self.kg.train_set
-            print('Submit er-vocab, re-vocab, and ee-vocab via  ProcessPoolExecutor...')
+            logger.info('Submit er-vocab, re-vocab, and ee-vocab via  ProcessPoolExecutor...')
             # We need to benchmark the benefits of using futures  ?
             executor = concurrent.futures.ProcessPoolExecutor()
             self.kg.er_vocab = executor.submit(get_er_vocab, data, self.kg.path_for_serialization + '/er_vocab.p')
             self.kg.re_vocab = executor.submit(get_re_vocab, data, self.kg.path_for_serialization + '/re_vocab.p')
             self.kg.ee_vocab = executor.submit(get_ee_vocab, data, self.kg.path_for_serialization + '/ee_vocab.p')
 
-        assert isinstance(self.kg.raw_train_set, (pd.DataFrame, pl.DataFrame))
+        if not isinstance(self.kg.raw_train_set, (pd.DataFrame, pl.DataFrame)):
+            raise TypeError(f"raw_train_set must be a pandas or polars DataFrame, got {type(self.kg.raw_train_set)}")
 
         if self.kg.byte_pair_encoding and self.kg.padding:
-            assert isinstance(self.kg.train_set, list)
-            assert isinstance(self.kg.train_set[0], tuple)
-            assert isinstance(self.kg.train_set[0][0], tuple)
-            assert isinstance(self.kg.train_set[0][1], tuple)
-            assert isinstance(self.kg.train_set[0][2], tuple)
+            if not isinstance(self.kg.train_set, list):
+                raise TypeError(f"train_set must be a list after BPE padding, got {type(self.kg.train_set)}")
+            if not isinstance(self.kg.train_set[0], tuple) or len(self.kg.train_set[0]) != 3:
+                raise TypeError("Each element of train_set must be a (subject, relation, object) tuple")
+            if not all(isinstance(self.kg.train_set[0][i], tuple) for i in range(3)):
+                raise TypeError("Each triple element of train_set must be a tuple of BPE token ids")
 
             if self.kg.training_technique == "NegSample":
                 """No need to do anything"""
@@ -160,11 +165,12 @@ class PreprocessKG:
             return []
         else:
             bpe_triples = list(df.map(lambda x: tuple(f(x))).itertuples(index=False, name=None))
-            assert isinstance(bpe_triples, list)
-            assert isinstance(bpe_triples[0], tuple)
-            assert len(bpe_triples[0]) == 3
-            assert isinstance(bpe_triples[0][0], tuple)
-            assert isinstance(bpe_triples[0][0][0], int)
+            if not isinstance(bpe_triples, list) or not bpe_triples:
+                raise TypeError("BPE encoding of the dataframe did not yield a non-empty list of triples")
+            if not isinstance(bpe_triples[0], tuple) or len(bpe_triples[0]) != 3:
+                raise TypeError("Each BPE-encoded triple must be a (subject, relation, object) tuple")
+            if not isinstance(bpe_triples[0][0], tuple) or not isinstance(bpe_triples[0][0][0], int):
+                raise TypeError("BPE-encoded subject must be a tuple of int token ids")
             return bpe_triples
 
     def __finding_max_token(self, concat_of_train_val_test) -> int:
@@ -202,8 +208,13 @@ class PreprocessKG:
         return x
 
     def preprocess_with_byte_pair_encoding(self):
-        assert isinstance(self.kg.raw_train_set, pd.DataFrame)
-        assert self.kg.raw_train_set.columns.tolist() == ['subject', 'relation', 'object']
+        if not isinstance(self.kg.raw_train_set, pd.DataFrame):
+            raise TypeError(f"raw_train_set must be a pandas DataFrame, got {type(self.kg.raw_train_set)}")
+        if self.kg.raw_train_set.columns.tolist() != ['subject', 'relation', 'object']:
+            raise ValueError(
+                f"raw_train_set must have columns ['subject', 'relation', 'object'], "
+                f"got {self.kg.raw_train_set.columns.tolist()}"
+            )
 
         # Add reciprocal or noisy triples
         self.kg.raw_train_set = apply_reciprocal_or_noise(add_reciprocal=self.kg.add_reciprocal,
@@ -233,8 +244,7 @@ class PreprocessKG:
         bpe_subwords_to_shaped_bpe_entities = dict()
         bpe_subwords_to_shaped_bpe_relations = dict()
 
-        print("The longest sequence of sub-word units of entities and relations is ",
-              self.kg.max_length_subword_tokens)
+        logger.info(f"The longest sequence of sub-word units of entities and relations is {self.kg.max_length_subword_tokens}")
         # Padding
         self.kg.train_set = self.__padding_in_place(self.kg.train_set, self.kg.max_length_subword_tokens,
                                                     bpe_subwords_to_shaped_bpe_entities,
@@ -277,7 +287,7 @@ class PreprocessKG:
 
         # Index and convert datasets
         def index_and_convert(df, name):
-            print(f'Indexing {name} data with shape {df.shape}...')
+            logger.info(f'Indexing {name} data with shape {df.shape}...')
             indexed = pandas_dataframe_indexer(df, self.kg.entity_to_idx, self.kg.relation_to_idx).values
             dataset_sanity_checking(indexed, self.kg.num_entities, self.kg.num_relations)
             return numpy_data_type_changer(indexed, num=max_idx)
@@ -293,7 +303,7 @@ class PreprocessKG:
     @timeit
     def preprocess_with_polars(self) -> None:
         """Preprocess with polars: add reciprocal triples and create indexed datasets"""
-        print(f'*** Preprocessing Train Data:{self.kg.raw_train_set.shape} with Polars ***')
+        logger.info(f'*** Preprocessing Train Data:{self.kg.raw_train_set.shape} with Polars ***')
 
         # Add reciprocal triples
         if self.kg.add_reciprocal and self.kg.eval_model:
@@ -306,17 +316,20 @@ class PreprocessKG:
                     ]))
                 return df
 
-            print('Adding Reciprocal Triples...')
+            logger.info('Adding Reciprocal Triples...')
             self.kg.raw_train_set = add_reciprocal(self.kg.raw_train_set)
             self.kg.raw_valid_set = add_reciprocal(self.kg.raw_valid_set)
             self.kg.raw_test_set = add_reciprocal(self.kg.raw_test_set)
 
         # Type checking
-        assert isinstance(self.kg.raw_train_set, pl.DataFrame)
-        assert self.kg.raw_valid_set is None or isinstance(self.kg.raw_valid_set, pl.DataFrame)
-        assert self.kg.raw_test_set is None or isinstance(self.kg.raw_test_set, pl.DataFrame)
+        if not isinstance(self.kg.raw_train_set, pl.DataFrame):
+            raise TypeError(f"raw_train_set must be a polars DataFrame, got {type(self.kg.raw_train_set)}")
+        if self.kg.raw_valid_set is not None and not isinstance(self.kg.raw_valid_set, pl.DataFrame):
+            raise TypeError(f"raw_valid_set must be a polars DataFrame or None, got {type(self.kg.raw_valid_set)}")
+        if self.kg.raw_test_set is not None and not isinstance(self.kg.raw_test_set, pl.DataFrame):
+            raise TypeError(f"raw_test_set must be a polars DataFrame or None, got {type(self.kg.raw_test_set)}")
         # Concatenate all splits for vocabulary construction
-        print('Concat Splits...')
+        logger.info('Concat Splits...')
         splits = [self.kg.raw_train_set]
         if self.kg.raw_valid_set is not None:
             splits.append(self.kg.raw_valid_set)
@@ -325,35 +338,35 @@ class PreprocessKG:
         df_str_kg = pl.concat(splits)
 
         # Build entity vocabulary (sorted alphabetically for deterministic indexing)
-        print("Collecting entities...")
+        logger.info("Collecting entities...")
         subjects = df_str_kg.select(pl.col("subject").unique().alias("entity"))
         objects = df_str_kg.select(pl.col("object").unique().alias("entity"))
         self.kg.entity_to_idx = pl.concat([subjects, objects], how="vertical").unique().sort("entity")
         self.kg.entity_to_idx = self.kg.entity_to_idx.with_row_index("index").select(["index", "entity"])
-        print(f"Unique entities: {len(self.kg.entity_to_idx)}")
+        logger.info(f"Unique entities: {len(self.kg.entity_to_idx)}")
 
         # Build relation vocabulary (sorted alphabetically for deterministic indexing)
-        print('Relation Indexing...')
+        logger.info('Relation Indexing...')
         self.kg.relation_to_idx = df_str_kg.select(pl.col("relation").unique()).sort("relation")
         self.kg.relation_to_idx = self.kg.relation_to_idx.with_row_index("index").select(["index", "relation"])
         del df_str_kg
         # Index datasets
-        print(f'Indexing Training Data {self.kg.raw_train_set.shape}...')
+        logger.info(f'Indexing Training Data {self.kg.raw_train_set.shape}...')
         self.kg.train_set = polars_dataframe_indexer(self.kg.raw_train_set, self.kg.entity_to_idx,
                                                       self.kg.relation_to_idx).to_numpy()
 
         if self.kg.raw_valid_set is not None:
-            print(f'Indexing Val Data {self.kg.raw_valid_set.shape}...')
+            logger.info(f'Indexing Val Data {self.kg.raw_valid_set.shape}...')
             self.kg.valid_set = polars_dataframe_indexer(self.kg.raw_valid_set, self.kg.entity_to_idx,
                                                           self.kg.relation_to_idx).to_numpy()
 
         if self.kg.raw_test_set is not None:
-            print(f'Indexing Test Data {self.kg.raw_test_set.shape}...')
+            logger.info(f'Indexing Test Data {self.kg.raw_test_set.shape}...')
             self.kg.test_set = polars_dataframe_indexer(self.kg.raw_test_set, self.kg.entity_to_idx,
                                                          self.kg.relation_to_idx).to_numpy()
 
         self.kg.num_entities, self.kg.num_relations = len(self.kg.entity_to_idx), len(self.kg.relation_to_idx)
-        print(f'*** Preprocessing Train Data:{self.kg.train_set.shape} with Polars DONE ***')
+        logger.info(f'*** Preprocessing Train Data:{self.kg.train_set.shape} with Polars DONE ***')
 
     def sequential_vocabulary_construction(self) -> None:
         """
@@ -363,19 +376,22 @@ class PreprocessKG:
                     => the index is integer and
                     => a single column is string (e.g. URI)
         """
-        assert isinstance(self.kg.raw_train_set, pd.DataFrame)
-        assert self.kg.raw_valid_set is None or isinstance(self.kg.raw_valid_set, pd.DataFrame)
-        assert self.kg.raw_test_set is None or isinstance(self.kg.raw_test_set, pd.DataFrame)
+        if not isinstance(self.kg.raw_train_set, pd.DataFrame):
+            raise TypeError(f"raw_train_set must be a pandas DataFrame, got {type(self.kg.raw_train_set)}")
+        if self.kg.raw_valid_set is not None and not isinstance(self.kg.raw_valid_set, pd.DataFrame):
+            raise TypeError(f"raw_valid_set must be a pandas DataFrame or None, got {type(self.kg.raw_valid_set)}")
+        if self.kg.raw_test_set is not None and not isinstance(self.kg.raw_test_set, pd.DataFrame):
+            raise TypeError(f"raw_test_set must be a pandas DataFrame or None, got {type(self.kg.raw_test_set)}")
 
         # Concatenate all data splits
-        print('Concatenating data to build vocabulary...')
+        logger.info('Concatenating data to build vocabulary...')
         splits = [self.kg.raw_train_set]
         if self.kg.raw_valid_set is not None:
             splits.append(self.kg.raw_valid_set)
         if self.kg.raw_test_set is not None:
             splits.append(self.kg.raw_test_set)
         df_str_kg = pd.concat(splits, ignore_index=True)
-        print('Creating a mapping from entities to integer indexes...')
+        logger.info('Creating a mapping from entities to integer indexes...')
         # (5) Create a bijection mapping from entities of (2) to integer indexes.
         # Build entity vocabulary (sorted alphabetically for deterministic indexing)
         # This ensures the same entity always gets the same index regardless of input order

--- a/dicee/read_preprocess_save_load_kg/read_from_disk.py
+++ b/dicee/read_preprocess_save_load_kg/read_from_disk.py
@@ -1,9 +1,12 @@
 import glob
+import logging
 
 import numpy as np
 import pandas as pd
 
 from .util import read_from_disk, read_from_triple_store_with_pandas, read_from_triple_store_with_polars
+
+logger = logging.getLogger(__name__)
 
 
 class ReadFromDisk:
@@ -58,7 +61,7 @@ class ReadFromDisk:
                 elif 'valid' in i and self.kg.eval_model is not None:
                     self.kg.raw_valid_set = read_from_disk(i, backend=self.kg.backend, separator=self.kg.separator)
                 else:
-                    print(f'Not processed data: {i}')
+                    logger.warning(f'Not processed data: {i}')
         else:
             raise RuntimeError(f"Invalid data:{self.kg.data_dir}\t{self.kg.sparql_endpoint}\t{self.kg.path_single_kg}")
 

--- a/dicee/read_preprocess_save_load_kg/save_load_disk.py
+++ b/dicee/read_preprocess_save_load_kg/save_load_disk.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import numpy as np
@@ -7,6 +8,8 @@ import polars
 from dicee.static_funcs import save_numpy_ndarray, save_pickle
 
 from .util import load_numpy_ndarray, load_pickle
+
+logger = logging.getLogger(__name__)
 
 
 class LoadSaveToDisk:
@@ -22,7 +25,7 @@ class LoadSaveToDisk:
 
         if self.kg.byte_pair_encoding:
             save_numpy_ndarray(data=self.kg.train_set, file_path=self.kg.path_for_serialization + '/train_set.npy')
-            print("NO SAVING for BPE at save_load_disk.py")
+            logger.warning("NO SAVING for BPE at save_load_disk.py")
             save_pickle(data=self.kg.ordered_bpe_entities, file_path=self.kg.path_for_serialization + '/ordered_bpe_entities.p')
             save_pickle(data=self.kg.ordered_bpe_relations, file_path=self.kg.path_for_serialization + '/ordered_bpe_relations.p')
         else:

--- a/dicee/read_preprocess_save_load_kg/util.py
+++ b/dicee/read_preprocess_save_load_kg/util.py
@@ -1,5 +1,6 @@
 import functools
 import glob
+import logging
 import os
 import pickle
 import time
@@ -16,6 +17,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import requests
 from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
 
 
 def polars_dataframe_indexer(df_polars:polars.DataFrame, idx_entity:polars.DataFrame, idx_relation:polars.DataFrame)->polars.DataFrame:
@@ -130,7 +133,7 @@ def pandas_dataframe_indexer(df_pandas: pd.DataFrame, idx_entity: pd.DataFrame, 
 def apply_reciprocal_or_noise(add_reciprocal: bool, eval_model: str, df: object = None, info: str = None):
     """Add reciprocal triples if conditions are met"""
     if add_reciprocal and eval_model and df is not None:
-        print(f'Adding reciprocal triples to {info}, e.g. KG:= (s, p, o) union (o, p_inverse, s)')
+        logger.info(f'Adding reciprocal triples to {info}, e.g. KG:= (s, p, o) union (o, p_inverse, s)')
         return create_recipriocal_triples(df)
     return df
 
@@ -142,7 +145,7 @@ def timeit(func):
         result = func(*args, **kwargs)
         end_time = time.perf_counter()
         total_time = end_time - start_time
-        print(
+        logger.info(
             f'{func.__name__} took {total_time:.4f} seconds '
             f'| Current Memory Usage {psutil.Process(os.getpid()).memory_info().rss / 1000000: .5} in MB')
         return result
@@ -154,7 +157,7 @@ def _filter_literal_triples(df, backend: str):
     """Remove triples with literal values if RDF format detected"""
     sample = df.head().to_pandas() if backend == "polars" else df.head()
     if sum(sample["subject"].str.startswith('<')) + sum(sample["relation"].str.startswith('<')) > 2:
-        print('Removing triples with literal values...')
+        logger.info('Removing triples with literal values...')
         if backend == "polars":
             return df.filter(polars.col("object").str.starts_with('<'))
         else:
@@ -166,7 +169,7 @@ def _filter_literal_triples(df, backend: str):
 def read_with_polars(data_path, read_only_few: int = None, sample_triples_ratio: float = None, separator:str=None) -> polars.DataFrame:
     """Load and Preprocess via Polars"""
     assert separator is not None, "separator cannot be None"
-    print(f'*** Reading {data_path} with Polars ***')
+    logger.info(f'*** Reading {data_path} with Polars ***')
 
     if ".zst" in data_path:
         df = polars.read_csv(data_path, n_rows=read_only_few)
@@ -181,9 +184,9 @@ def read_with_polars(data_path, read_only_few: int = None, sample_triples_ratio:
                              separator=separator)
 
     if sample_triples_ratio:
-        print(f'Subsampling {sample_triples_ratio} of input data {df.shape}...')
+        logger.info(f'Subsampling {sample_triples_ratio} of input data {df.shape}...')
         df = df.sample(frac=sample_triples_ratio)
-        print(df.shape)
+        logger.info(df.shape)
 
     return _filter_literal_triples(df, "polars")
 
@@ -210,7 +213,7 @@ def _read_parquet_head(data_path: str, read_only_few: int) -> pd.DataFrame:
 def read_with_pandas(data_path, read_only_few: int = None, sample_triples_ratio: float = None, separator:str=None):
     """Load and Preprocess via Pandas"""
     assert separator is not None, "separator cannot be None"
-    print(f'*** Reading {data_path} with Pandas ***')
+    logger.info(f'*** Reading {data_path} with Pandas ***')
 
     if data_path[-3:] in [".nt", "ttl", 'txt', 'csv', 'zst']:
         df = pd.read_csv(data_path,
@@ -222,13 +225,13 @@ def read_with_pandas(data_path, read_only_few: int = None, sample_triples_ratio:
                          dtype=str)
     else:
         if read_only_few and read_only_few > 0:
-            print(f'Reading only few input data {read_only_few}...')
+            logger.info(f'Reading only few input data {read_only_few}...')
             df = _read_parquet_head(data_path, read_only_few)
         else:
             df = pd.read_parquet(data_path, engine='pyarrow')
 
     if sample_triples_ratio:
-        print(f'Subsampling {sample_triples_ratio} of input data...')
+        logger.info(f'Subsampling {sample_triples_ratio} of input data...')
         df = df.sample(frac=sample_triples_ratio)
 
     return _filter_literal_triples(df, "pandas")
@@ -299,7 +302,7 @@ def fetch_worker(endpoint: str, offsets: list[int], chunk_size: int, output_dir:
         """
         response = requests.post(endpoint, data={"query": query}, headers=headers)
         if not response.ok:
-            print(f"[Worker {worker_id}] Query failed at offset {offset}: {response.status_code}")
+            logger.warning(f"[Worker {worker_id}] Query failed at offset {offset}: {response.status_code}")
             continue
 
         bindings = response.json()["results"]["bindings"]
@@ -318,18 +321,18 @@ def read_from_triple_store_with_polars(endpoint: str, chunk_size: int = 500000, 
     if os.path.exists(output_dir):
         files = [os.path.join(output_dir, f) for f in os.listdir(output_dir) if f.endswith(".parquet")]
         if files:
-            print(f"\n*** Found parquet files in folder `{output_dir}`, will read from those. Otherwise, delete the folder.***\n")
+            logger.info(f"Found parquet files in folder `{output_dir}`, will read from those. Otherwise, delete the folder.")
             parquet_files = sorted(files)
             df_polars = pl.read_parquet(parquet_files)
             return df_polars
 
     total_triples = count_triples(endpoint)
     total_chunks = (total_triples + chunk_size - 1) // chunk_size
-    print(f"Total triples: {total_triples}, total chunks: {total_chunks}")
+    logger.info(f"Total triples: {total_triples}, total chunks: {total_chunks}")
 
     # Determine number of workers
     num_workers = max(1, cpu_count())
-    print(f"Using {num_workers} worker processes.")
+    logger.info(f"Using {num_workers} worker processes.")
 
     # Generate all offsets
     all_offsets = [i * chunk_size for i in range(total_chunks)]
@@ -444,46 +447,46 @@ def create_constraints(triples, file_path: str = None):
 @timeit
 def load_with_pandas(self) -> None:
     """ Deserialize data """
-    print(f'Deserialization Path: {self.kg.deserialize_flag}\n')
+    logger.info(f'Deserialization Path: {self.kg.deserialize_flag}')
     start_time = time.time()
-    print('[1 / 4] Deserializing compressed entity integer mapping...')
+    logger.info('[1 / 4] Deserializing compressed entity integer mapping...')
     self.kg.entity_to_idx = pd.read_parquet(self.kg.deserialize_flag + '/entity_to_idx.gzip')
-    print(f'Done !\t{time.time() - start_time:.3f} seconds\n')
+    logger.info(f'Done !\t{time.time() - start_time:.3f} seconds')
     self.kg.num_entities = len(self.kg.entity_to_idx)
 
-    print('[2 / ] Deserializing compressed relation integer mapping...')
+    logger.info('[2 / ] Deserializing compressed relation integer mapping...')
     start_time = time.time()
     self.kg.relation_to_idx = pd.read_parquet(self.kg.deserialize_flag + '/relation_to_idx.gzip')
-    print(f'Done !\t{time.time() - start_time:.3f} seconds\n')
+    logger.info(f'Done !\t{time.time() - start_time:.3f} seconds')
 
     self.kg.num_relations = len(self.kg.relation_to_idx)
-    print(
+    logger.info(
         '[3 / 4] Converting integer and relation mappings '
         'from from pandas dataframe to dictionaries for an easy access...',
     )
     start_time = time.time()
     self.kg.entity_to_idx = self.kg.entity_to_idx.to_dict()['entity']
     self.kg.relation_to_idx = self.kg.relation_to_idx.to_dict()['relation']
-    print(f'Done !\t{time.time() - start_time:.3f} seconds\n')
+    logger.info(f'Done !\t{time.time() - start_time:.3f} seconds')
     # 10. Serialize (9).
-    print('[4 / 4] Deserializing integer mapped data and mapping it to numpy ndarray...')
+    logger.info('[4 / 4] Deserializing integer mapped data and mapping it to numpy ndarray...')
     start_time = time.time()
     self.kg.train_set = pd.read_parquet(self.kg.deserialize_flag + '/idx_train_df.gzip').values
-    print(f'Done !\t{time.time() - start_time:.3f} seconds\n')
+    logger.info(f'Done !\t{time.time() - start_time:.3f} seconds')
     try:
-        print('[5 / 4] Deserializing integer mapped data and mapping it to numpy ndarray...')
+        logger.info('[5 / 4] Deserializing integer mapped data and mapping it to numpy ndarray...')
         self.kg.valid_set = pd.read_parquet(self.kg.deserialize_flag + '/idx_valid_df.gzip').values
-        print('Done!\n')
+        logger.info('Done!')
     except FileNotFoundError:
-        print('No valid data found!\n')
+        logger.info('No valid data found!')
         self.kg.valid_set = None  # pd.DataFrame()
 
     try:
-        print('[6 / 4] Deserializing integer mapped data and mapping it to numpy ndarray...')
+        logger.info('[6 / 4] Deserializing integer mapped data and mapping it to numpy ndarray...')
         self.kg.test_set = pd.read_parquet(self.kg.deserialize_flag + '/idx_test_df.gzip').values
-        print('Done!\n')
+        logger.info('Done!')
     except FileNotFoundError:
-        print('No test data found\n')
+        logger.info('No test data found')
         self.kg.test_set = None
 
     if self.kg.eval_model:
@@ -492,7 +495,7 @@ def load_with_pandas(self) -> None:
             data = np.concatenate([self.kg.train_set, self.kg.valid_set, self.kg.test_set])
         else:
             data = self.kg.train_set
-        print('[7 / 4] Creating er,re, and ee type vocabulary for evaluation...')
+        logger.info('[7 / 4] Creating er,re, and ee type vocabulary for evaluation...')
         start_time = time.time()
         self.kg.er_vocab = get_er_vocab(data)
         self.kg.re_vocab = get_re_vocab(data)
@@ -500,7 +503,7 @@ def load_with_pandas(self) -> None:
         self.kg.ee_vocab = get_ee_vocab(data)
         self.kg.domain_constraints_per_rel, self.kg.range_constraints_per_rel = create_constraints(
             self.kg.train_set)
-        print(f'Done !\t{time.time() - start_time:.3f} seconds\n')
+        logger.info(f'Done !\t{time.time() - start_time:.3f} seconds')
 
 
 def save_numpy_ndarray(*, data: np.ndarray, file_path: str):
@@ -563,7 +566,7 @@ def dataset_sanity_checking(train_set: np.ndarray, num_entities: int, num_relati
     try:
         assert num_relations >= max(train_set[:, 1])
     except AssertionError:
-        print(
+        logger.warning(
             f'Relation Indexing Error:\n'
             f'Max ID of a relation in train set:{max(train_set[:, 1])} is greater than num_entities:{num_relations}')
     # 13. Sanity checking: data types

--- a/dicee/sanity_checkers.py
+++ b/dicee/sanity_checkers.py
@@ -1,8 +1,11 @@
 import glob
+import logging
 import os
 
 import requests
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 def is_sparql_endpoint_alive(sparql_endpoint: str = None):
@@ -10,7 +13,7 @@ def is_sparql_endpoint_alive(sparql_endpoint: str = None):
         query = """SELECT (COUNT(*) as ?num_triples) WHERE {  ?s ?p ?o .} """
         response = requests.post(sparql_endpoint, data={'query': query})
         assert response.ok
-        print('SPARQL connection is successful')
+        logger.info('SPARQL connection is successful')
         return response.ok
     else:
         return False

--- a/dicee/scripts/index_serve.py
+++ b/dicee/scripts/index_serve.py
@@ -4,6 +4,7 @@ $ dicee_vector_db --index --serve --path CountryEmbeddings --collection "countri
 
 """
 import argparse
+import logging
 import os
 from typing import List, Optional
 
@@ -14,6 +15,8 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import Distance, PointStruct, VectorParams
+
+logger = logging.getLogger(__name__)
 
 
 def get_default_arguments():
@@ -60,15 +63,15 @@ def index(args):
     assert embedding_dim > 0
     # If the collection is not created, create it
     if args.collection in [i.name for i in client.get_collections().collections]:
-        print("Deleting existing collection ", args.collection)
+        logger.info(f"Deleting existing collection {args.collection}")
         client.delete_collection(collection_name=args.collection)
 
-    print(f"Creating a collection {args.collection} with distance metric:Cosine")
+    logger.info(f"Creating a collection {args.collection} with distance metric:Cosine")
     client.create_collection(collection_name=args.collection,
                              vectors_config=VectorParams(size=embedding_dim,
                                                          distance=Distance.COSINE))
     client.upsert(collection_name=args.collection, points=points)
-    print("Completed!")
+    logger.info("Completed!")
 
 
 app = FastAPI()

--- a/dicee/static_funcs.py
+++ b/dicee/static_funcs.py
@@ -8,6 +8,7 @@ import datetime
 import functools
 import glob
 import json
+import logging
 import os
 import pickle
 import time
@@ -29,6 +30,8 @@ from .models.ensemble import EnsembleKGE
 from .models.fsdp_models import create_fsdp_sharded_model_class
 from .models.pykeen_models import PykeenKGE
 from .models.transformers import BytE
+
+logger = logging.getLogger(__name__)
 
 # Model registry mapping model names to their classes and labelling types
 MODEL_REGISTRY: Dict[str, Tuple[Type, str]] = {
@@ -143,7 +146,7 @@ def timeit(func: Callable) -> Callable:
         result = func(*args, **kwargs)
         total_time = time.perf_counter() - start_time
         memory_mb = psutil.Process(os.getpid()).memory_info().rss / 1_000_000
-        print(f'Took {total_time:.4f} secs | Current Memory Usage {memory_mb:.5f} MB')
+        logger.info(f'Took {total_time:.4f} secs | Current Memory Usage {memory_mb:.5f} MB')
         return result
     return timeit_wrapper
 
@@ -183,7 +186,7 @@ def setup_distributed_training(args) -> Dict[str, Union[bool, int]]:
                 )
             rank = dist.get_rank()
             world_size = dist.get_world_size()
-            print(f"[Rank {rank}] mapped to GPU {local_rank}", flush=True)
+            logger.info(f"[Rank {rank}] mapped to GPU {local_rank}")
     else:
         distributed = False
         rank, world_size, local_rank = 0, 1, 0
@@ -208,7 +211,7 @@ def save_pickle(*, data: Optional[object] = None, file_path: str) -> None:
         with open(file_path, 'wb') as f:
             pickle.dump(data, f)
     else:
-        print("Input data is None. Nothing to save.")
+        logger.warning("Input data is None. Nothing to save.")
 
 
 def load_pickle(file_path: str) -> object:
@@ -240,7 +243,7 @@ def load_term_mapping(file_path: str) -> Union[dict, pl.DataFrame]:
     try:
         return load_pickle(file_path=pickle_path)
     except FileNotFoundError:
-        print(f"Pickle file not found: {pickle_path}, loading from CSV")
+        logger.info(f"Pickle file not found: {pickle_path}, loading from CSV")
         return pl.read_csv(f"{file_path}.csv")
 
 # @TODO: Could these funcs can be merged?
@@ -266,7 +269,7 @@ def select_model(args: dict, is_continual_training: bool = None, storage_path: s
                 models.append(model)
             return EnsembleKGE(pretrained_models=models), labelling_flag
         else:
-            print('Loading pre-trained model...')
+            logger.info('Loading pre-trained model...')
             model, labelling_flag = intialize_model(args)
             try:
                 weights = torch.load(storage_path + '/model.pt', torch.device('cpu'))
@@ -275,7 +278,7 @@ def select_model(args: dict, is_continual_training: bool = None, storage_path: s
                     parameter.requires_grad = True
                 model.train()
             except FileNotFoundError as e:
-                print(f"{storage_path}/model.pt is not found. The model will be trained with random weights")
+                logger.warning(f"{storage_path}/model.pt is not found. The model will be trained with random weights")
                 raise e
             return model, labelling_flag
     else:
@@ -296,7 +299,7 @@ def select_model(args: dict, is_continual_training: bool = None, storage_path: s
 def load_model(path_of_experiment_folder: str, model_name='model.pt',verbose=0) -> Tuple[object, Tuple[dict, dict]]:
     """ Load weights and initialize pytorch module from namespace arguments"""
     if verbose>0:
-        print(f'Loading model {model_name}...', end=' ')
+        logger.info(f'Loading model {model_name}...')
     start_time = time.time()
     # (1) Load weights..
     weights = torch.load(path_of_experiment_folder + f'/{model_name}', torch.device('cpu'))
@@ -320,7 +323,7 @@ def load_model(path_of_experiment_folder: str, model_name='model.pt',verbose=0) 
         configs["num_entities"] = num_ent
         configs["num_relations"] = num_rel
     if verbose>0:
-        print(f'Done! It took {time.time() - start_time:.3f}')
+        logger.info(f'Done! It took {time.time() - start_time:.3f}')
     # (4) Select the model
     model, _ = intialize_model(configs,verbose)
     # (5) Put (1) into (4)
@@ -337,7 +340,7 @@ def load_model(path_of_experiment_folder: str, model_name='model.pt',verbose=0) 
         return model, None
     else:
         if verbose>0:
-            print('Loading entity and relation indexes...', end=' ')
+            logger.info('Loading entity and relation indexes...')
 
         # Use per-column dtype to avoid pandas>=3.0.0 applying dtype=str to the index column
         # (which would make index values strings instead of ints, breaking downstream assertions)
@@ -347,7 +350,7 @@ def load_model(path_of_experiment_folder: str, model_name='model.pt',verbose=0) 
 
 
         if verbose > 0:
-            print(f'Done! It took {time.time() - start_time:.4f}')
+            logger.info(f'Done! It took {time.time() - start_time:.4f}')
         return model, (entity_to_idx, relation_to_idx)
 
 
@@ -359,18 +362,19 @@ def load_model_ensemble(path_of_experiment_folder: str) -> Tuple[BaseKGE, Tuple[
     (3) Normalize parameters
     (4) Insert (3) into model.
     """
-    print('Constructing Ensemble of ', end=' ')
+    logger.info('Constructing Ensemble of models...')
     start_time = time.time()
     # (1) Detect models under given path.
     paths_for_loading = glob.glob(path_of_experiment_folder + '/model*')
-    print(f'{len(paths_for_loading)} models...')
-    assert len(paths_for_loading) > 0
+    logger.info(f'{len(paths_for_loading)} models...')
+    if len(paths_for_loading) == 0:
+        raise ValueError(f"No model files found under {path_of_experiment_folder}")
     num_of_models = len(paths_for_loading)
     weights = None
     # (2) Accumulate parameters of detected models.
     while len(paths_for_loading):
         p = paths_for_loading.pop()
-        print(f'Model: {p}...')
+        logger.info(f'Model: {p}...')
         if weights is None:
             weights = torch.load(p, torch.device('cpu'))
         else:
@@ -389,18 +393,18 @@ def load_model_ensemble(path_of_experiment_folder: str) -> Tuple[BaseKGE, Tuple[
     report = load_json(path_of_experiment_folder + '/report.json')
     configs["num_entities"] = report["num_entities"]
     configs["num_relations"] = report["num_relations"]
-    print(f'Done! It took {time.time() - start_time:.2f} seconds.')
+    logger.info(f'Done! It took {time.time() - start_time:.2f} seconds.')
     # (4.2) Select the model
     model, _ = intialize_model(configs)
     # (4.3) Put (3) into their places
     model.load_state_dict(weights, strict=True)
     # (6) Set it into eval model.
-    print('Setting Eval mode & requires_grad params to False')
+    logger.info('Setting Eval mode & requires_grad params to False')
     for parameter in model.parameters():
         parameter.requires_grad = False
     model.eval()
     start_time = time.time()
-    print('Loading entity and relation indexes...', end=' ')
+    logger.info('Loading entity and relation indexes...')
     # TODO: CD: We do not need to keep the mapping in memory
     # TODO:CD: Deprecate the pickle usage for data serialization.
 
@@ -413,7 +417,7 @@ def load_model_ensemble(path_of_experiment_folder: str) -> Tuple[BaseKGE, Tuple[
 
     assert isinstance(entity_to_idx, dict)
     assert isinstance(relation_to_idx, dict)
-    print(f'Done! It took {time.time() - start_time:.4f}')
+    logger.info(f'Done! It took {time.time() - start_time:.4f}')
     return model, (entity_to_idx, relation_to_idx)
 
 
@@ -466,13 +470,13 @@ def store(trained_model, model_name: str = 'model', full_storage_path: str = Non
 
     if save_embeddings_as_csv:
         entity_emb, relation_ebm = trained_model.get_embeddings()
-        print("Saving entity embeddings...")
+        logger.info("Saving entity embeddings...")
         entity=pd.read_csv(f"{full_storage_path}/entity_to_idx.csv",index_col=0)["entity"]
         assert entity.index.is_monotonic_increasing
         save_embeddings(entity_emb.numpy(), indexes=entity.to_list(), path=full_storage_path + '/' + trained_model.name + '_entity_embeddings.csv')
         del entity, entity_emb
         if relation_ebm is not None:
-            print("Saving relation embeddings...")
+            logger.info("Saving relation embeddings...")
             relations = pd.read_csv(f"{full_storage_path}/relation_to_idx.csv", index_col=0)["relation"]
             assert relations.index.is_monotonic_increasing
             save_embeddings(relation_ebm.numpy(), indexes=relations, path=full_storage_path + '/' + trained_model.name + '_relation_embeddings.csv')
@@ -488,7 +492,7 @@ def add_noisy_triples(train_set: pd.DataFrame, add_noise_rate: float) -> pd.Data
     """
     num_triples = len(train_set)
     num_noisy_triples = int(num_triples * add_noise_rate)
-    print(f'[4 / 14] Generating {num_noisy_triples} noisy triples for training data...')
+    logger.info(f'[4 / 14] Generating {num_noisy_triples} noisy triples for training data...')
 
     list_of_entities = pd.unique(train_set[['subject', 'object']].values.ravel())
 
@@ -509,7 +513,7 @@ def add_noisy_triples(train_set: pd.DataFrame, add_noise_rate: float) -> pd.Data
     return train_set
 
 def read_or_load_kg(args, cls):
-    print('*** Read or Load Knowledge Graph  ***')
+    logger.info('*** Read or Load Knowledge Graph  ***')
     start_time = time.time()
     kg = cls(dataset_dir=args.dataset_dir,
              byte_pair_encoding=args.byte_pair_encoding,
@@ -526,9 +530,9 @@ def read_or_load_kg(args, cls):
              backend=args.backend,
              training_technique=args.scoring_technique,
              separator=args.separator)
-    print(f'Preprocessing took: {time.time() - start_time:.3f} seconds')
+    logger.info(f'Preprocessing took: {time.time() - start_time:.3f} seconds')
     # (2) Share some info about data for easy access.
-    print(kg.description_of_input)
+    logger.info(kg.description_of_input)
     return kg
 
 
@@ -546,7 +550,7 @@ def intialize_model(args: Dict, verbose: int = 0) -> Tuple[BaseKGE, str]:
         ValueError: If the model name is not recognized.
     """
     if verbose > 0:
-        print(f"Initializing {args['model']}...")
+        logger.info(f"Initializing {args['model']}...")
     model_name = args['model']
 
     # Handle PyKEEN models
@@ -584,7 +588,7 @@ def intialize_model(args: Dict, verbose: int = 0) -> Tuple[BaseKGE, str]:
 def _legacy_intialize_model(args: dict, verbose: int = 0) -> Tuple[object, str]:
     """Legacy model initialization (deprecated, use intialize_model instead)."""
     if verbose > 0:
-        print(f"Initializing {args['model']}...")
+        logger.info(f"Initializing {args['model']}...")
     model_name = args['model']
     if "pykeen" in model_name.lower():
         model = PykeenKGE(args=args)
@@ -685,16 +689,16 @@ def save_embeddings(embeddings: np.ndarray, indexes: List, path: str) -> None:
     try:
         pd.DataFrame(embeddings, index=indexes).to_csv(path)
     except (KeyError, AttributeError) as e:
-        print(f'Exception occurred while saving embeddings: {e}')
-        print('Computation will continue.')
+        logger.warning(f'Exception occurred while saving embeddings: {e}')
+        logger.warning('Computation will continue.')
 
 
 @timeit
 def vocab_to_parquet(vocab_to_idx, name, path_for_serialization, print_into):
     # @TODO: This function should take any DASK/Pandas DataFrame or Series.
-    print(print_into)
+    logger.info(print_into)
     vocab_to_idx.to_parquet(path_for_serialization + f'/{name}', compression='gzip', engine='pyarrow')
-    print('Done !\n')
+    logger.info('Done !')
 
 
 def create_experiment_folder(folder_name: str = 'Experiments') -> str:
@@ -742,7 +746,7 @@ def exponential_function(x: np.ndarray, lam: float, ascending_order=True) -> tor
 
 @timeit
 def load_numpy(path) -> np.ndarray:
-    print('Loading indexed training data...', end='')
+    logger.info('Loading indexed training data...')
     with open(path, 'rb') as f:
         data = np.load(f)
     return data
@@ -820,9 +824,9 @@ def download_file(url, destination_folder="."):
             for chunk in response.iter_content(chunk_size=1024):
                 if chunk:
                     file.write(chunk)
-        print(f"Downloaded: {filename}")
+        logger.info(f"Downloaded: {filename}")
     else:
-        print(f"Failed to download: {url}")
+        logger.error(f"Failed to download: {url}")
 
 
 def download_files_from_url(base_url:str, destination_folder=".")->None:
@@ -842,7 +846,7 @@ def download_files_from_url(base_url:str, destination_folder=".")->None:
     try:
         from bs4 import BeautifulSoup
     except ModuleNotFoundError:
-        print("Please install the 'beautifulsoup4' package by running: pip install beautifulsoup4")
+        logger.error("Please install the 'beautifulsoup4' package by running: pip install beautifulsoup4")
         raise
     response = requests.get(base_url)
     if response.status_code == 200:
@@ -856,14 +860,14 @@ def download_files_from_url(base_url:str, destination_folder=".")->None:
         for file_url in hrefs:
             download_file(base_url + "/" + file_url, destination_folder)
     else:
-        print("ERROR:", response.status_code)
+        logger.error(f"ERROR: {response.status_code}")
 
 def download_pretrained_model(url: str) -> str:
     assert url[-1] != "/"
     dir_name = url[url.rfind("/") + 1:]
     url_to_download_from = f"https://files.dice-research.org/projects/DiceEmbeddings/{dir_name}"
     if os.path.exists(dir_name):
-        print("Path exists", dir_name)
+        logger.info(f"Path exists: {dir_name}")
     else:
         os.mkdir(dir_name)
         download_files_from_url(url_to_download_from, destination_folder=dir_name)

--- a/dicee/static_preprocess_funcs.py
+++ b/dicee/static_preprocess_funcs.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import time
 from collections import defaultdict
 from typing import Tuple
@@ -6,6 +7,8 @@ from typing import Tuple
 import numpy as np
 
 from .sanity_checkers import sanity_check_callback_args, sanity_checking_with_arguments
+
+logger = logging.getLogger(__name__)
 
 enable_log = False
 def timeit(func):
@@ -24,9 +27,9 @@ def timeit(func):
                 s_kwargs = {k: type(v) for k, v in kwargs.items()}
             else:
                 s_kwargs = kwargs
-            print(f'Function {func.__name__} with  Args:{s_args} | Kwargs:{s_kwargs} took {total_time:.4f} seconds')
+            logger.info(f'Function {func.__name__} with  Args:{s_args} | Kwargs:{s_kwargs} took {total_time:.4f} seconds')
         else:
-            print(f'Took {total_time:.4f} seconds')
+            logger.info(f'Took {total_time:.4f} seconds')
 
         return result
 
@@ -94,7 +97,7 @@ def create_constraints(triples: np.ndarray) -> Tuple[dict, dict, dict, dict]:
     domain_constraints_per_rel = dict()
     set_of_entities = set()
     set_of_relations = set()
-    print(f'Constructing domain and range information by iterating over {len(triples)} triples...', end='\t')
+    logger.info(f'Constructing domain and range information by iterating over {len(triples)} triples...')
     for (e1, p, e2) in triples:
         # e1, p, e2 have numpy.int16 or else types.
         domain_per_rel.setdefault(p, set()).add(e1)
@@ -102,8 +105,7 @@ def create_constraints(triples: np.ndarray) -> Tuple[dict, dict, dict, dict]:
         set_of_entities.add(e1)
         set_of_relations.add(p)
         set_of_entities.add(e2)
-    print(f'Creating constraints based on {len(set_of_relations)} relations and {len(set_of_entities)} entities...',
-          end='\t')
+    logger.info(f'Creating constraints based on {len(set_of_relations)} relations and {len(set_of_entities)} entities...')
     for rel in set_of_relations:
         range_constraints_per_rel[rel] = list(set_of_entities - range_per_rel[rel])
         domain_constraints_per_rel[rel] = list(set_of_entities - domain_per_rel[rel])

--- a/dicee/trainer/auto_batch_finder.py
+++ b/dicee/trainer/auto_batch_finder.py
@@ -1,7 +1,10 @@
+import logging
 import time
 from typing import Callable, Optional, Tuple
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 def find_good_batch_size(
@@ -39,10 +42,10 @@ def find_good_batch_size(
         device = torch.device(device)
 
     if device.type != "cuda":
-        print("Auto batch finding requires a CUDA device — skipping.")
+        logger.warning("Auto batch finding requires a CUDA device — skipping.")
         return initial_batch_size, None
 
-    print(f"Auto batch finding — training data points: {training_dataset_size}")
+    logger.info(f"Auto batch finding — training data points: {training_dataset_size}")
 
     def _try_increasing(batch_size: int, delta: int):
         """Increase batch_size until OOM or >90 % GPU memory, return history."""
@@ -69,7 +72,7 @@ def find_good_batch_size(
                 pct_used = (total - free) / total
                 rt = time.time() - start
 
-                print(
+                logger.info(
                     f"Batch Loss: {batch_loss:.4f}\t"
                     f"GPU Usage: {pct_used:.3f}\t"
                     f"Runtime: {rt:.3f}s\t"
@@ -89,7 +92,7 @@ def find_good_batch_size(
         except torch.OutOfMemoryError:
             gpu_mem = torch.cuda.get_device_properties(device).total_memory / (1024 ** 3)
             allocated = torch.cuda.memory_allocated(device) / (1024 ** 3)
-            print(
+            logger.error(
                 f"CUDA OOM at batch_size={batch_size} "
                 f"({gpu_mem:.2f} GB total, {allocated:.2f} GB allocated)"
             )

--- a/dicee/trainer/dice_trainer.py
+++ b/dicee/trainer/dice_trainer.py
@@ -4,6 +4,7 @@ Provides the DICE_Trainer class which supports multiple training backends
 including PyTorch Lightning, DDP, and custom CPU/GPU trainers.
 """
 import copy
+import logging
 import os
 from typing import List, Optional, Tuple, Union
 
@@ -33,6 +34,8 @@ from .model_parallelism import TensorParallel
 from .torch_trainer import TorchTrainer
 from .torch_trainer_ddp import TorchDDPTrainer
 from .torch_trainer_fsdp import TorchFSDPTrainer
+
+logger = logging.getLogger(__name__)
 
 
 def load_term_mapping(file_path: str) -> polars.DataFrame:
@@ -101,21 +104,21 @@ def initialize_trainer(
     """
     trainer: Optional[Union[TorchTrainer, TensorParallel, TorchDDPTrainer, TorchFSDPTrainer, pl.Trainer]] = None
     if args.trainer == 'torchCPUTrainer':
-        print('Initializing TorchTrainer CPU Trainer...', end='\t')
+        logger.info('Initializing TorchTrainer CPU Trainer...')
         trainer = TorchTrainer(args, callbacks=callbacks)
     elif args.trainer == 'TP':
-        print('Initializing TensorParallel...', end='\t')
+        logger.info('Initializing TensorParallel...')
         trainer= TensorParallel(args, callbacks=callbacks)
     elif args.trainer == 'torchDDP':
         assert torch.cuda.is_available()
-        print('Initializing TorchDDPTrainer GPU', end='\t')
+        logger.info('Initializing TorchDDPTrainer GPU')
         trainer = TorchDDPTrainer(args, callbacks=callbacks)
     elif args.trainer == 'torchFSDP':
         assert torch.cuda.is_available()
-        print('Initializing TorchFSDPTrainer (row-wise sharded) GPU', end='\t')
+        logger.info('Initializing TorchFSDPTrainer (row-wise sharded) GPU')
         trainer = TorchFSDPTrainer(args, callbacks=callbacks)
     elif args.trainer == 'PL':
-        print('Initializing Pytorch-lightning Trainer', end='\t')
+        logger.info('Initializing Pytorch-lightning Trainer')
         kwargs = {**vars(args), **(getattr(args, "pl_trainer_kwargs", {}) or {})}
         # NOTE: PyTorch Lightning Trainer has many optional parameters
         # See: https://lightning.ai/docs/pytorch/stable/common/trainer.html
@@ -136,7 +139,7 @@ def initialize_trainer(
                           detect_anomaly=False,
                           barebones=False)
     else:
-        print('Initializing TorchTrainer CPU Trainer...', end='\t')
+        logger.info('Initializing TorchTrainer CPU Trainer...')
         trainer = TorchTrainer(args, callbacks=callbacks)
     assert trainer is not None
     return trainer
@@ -159,7 +162,7 @@ def get_callbacks(args) -> List:
 
     # Weight averaging callbacks (mutually exclusive)
     if args.swa:
-        print(f"Starting Stochastic Weight Averaging (SWA) at Epoch: {args.swa_start_epoch}")
+        logger.info(f"Starting Stochastic Weight Averaging (SWA) at Epoch: {args.swa_start_epoch}")
         callbacks.append(SWA(
             swa_start_epoch=args.swa_start_epoch,
             lr_init=args.lr,
@@ -167,7 +170,7 @@ def get_callbacks(args) -> List:
             swa_c_epochs=args.swa_c_epochs
         ))
     elif args.swag:
-        print(f"Starting Stochastic Weight Averaging-Gaussian (SWA-G) at Epoch: {args.swa_start_epoch}")
+        logger.info(f"Starting Stochastic Weight Averaging-Gaussian (SWA-G) at Epoch: {args.swa_start_epoch}")
         callbacks.append(SWAG(
             swa_start_epoch=args.swa_start_epoch,
             lr_init=args.lr,
@@ -175,14 +178,14 @@ def get_callbacks(args) -> List:
             swa_c_epochs=args.swa_c_epochs
         ))
     elif args.ema:
-        print(f"Starting Exponential Moving Average (EMA) at Epoch: {args.swa_start_epoch}")
+        logger.info(f"Starting Exponential Moving Average (EMA) at Epoch: {args.swa_start_epoch}")
         callbacks.append(EMA(
             ema_start_epoch=args.swa_start_epoch,
             max_epochs=args.num_epochs,
             ema_c_epochs=args.swa_c_epochs
         ))
     elif args.twa:
-        print(f"Starting Trainable Weight Averaging at Epoch: {args.swa_start_epoch}")
+        logger.info(f"Starting Trainable Weight Averaging at Epoch: {args.swa_start_epoch}")
         callbacks.append(TWA(
             twa_start_epoch=args.swa_start_epoch,
             lr_init=args.lr,
@@ -255,14 +258,14 @@ class DICE_Trainer:
         # Required for CV.
         self.evaluator = evaluator
         self.form_of_labelling = None
-        print(f'# of CPUs:{os.cpu_count()} |'
-              f' # of GPUs:{torch.cuda.device_count()} |'
-              f' # of CPUs for dataloader:{self.args.num_core}')
+        logger.info(f'# of CPUs:{os.cpu_count()} |'
+                    f' # of GPUs:{torch.cuda.device_count()} |'
+                    f' # of CPUs for dataloader:{self.args.num_core}')
         for i in range(torch.cuda.device_count()):
             try:
-                print(torch.cuda.get_device_name(i))
+                logger.info(torch.cuda.get_device_name(i))
             except Exception as exc:
-                print(f'GPU {i}: <unable to query name — {exc}>')
+                logger.warning(f'GPU {i}: <unable to query name — {exc}>')
 
     def continual_start(self,knowledge_graph):
         """
@@ -296,7 +299,7 @@ class DICE_Trainer:
 
     @timeit
     def initialize_or_load_model(self):
-        print('Initializing Model...', end='\t')
+        logger.info('Initializing Model...')
         model, form_of_labelling = select_model(vars(self.args), self.is_continual_training, self.storage_path)
         self.report['form_of_labelling'] = form_of_labelling
         assert form_of_labelling in ['EntityPrediction', 'RelationPrediction']
@@ -304,7 +307,7 @@ class DICE_Trainer:
 
     @timeit
     def init_dataloader(self, dataset: torch.utils.data.Dataset) -> torch.utils.data.DataLoader:
-        print('Initializing Dataloader...', end='\t')
+        logger.info('Initializing Dataloader...')
         # https://pytorch.org/docs/stable/data.html#multi-process-data-loading
         # https://github.com/pytorch/pytorch/issues/13246#issuecomment-905703662
         return torch.utils.data.DataLoader(dataset=dataset, batch_size=self.args.batch_size,
@@ -313,7 +316,7 @@ class DICE_Trainer:
 
     @timeit
     def init_dataset(self) -> torch.utils.data.Dataset:
-        print('Initializing Dataset...', end='\t')
+        logger.info('Initializing Dataset...')
         if isinstance(self.trainer.dataset,KG):
             sort_train_set = self.args.trainer not in {"torchFSDP"}
             # Create a memory map of training dataset to reduce the memory usage
@@ -383,7 +386,7 @@ class DICE_Trainer:
         in DDP setup, we need to load the memory map of already read/index KG.
         """
         """ Train selected model via the selected training strategy """
-        print('------------------- Train -------------------')
+        logger.info('------------------- Train -------------------')
         assert isinstance(knowledge_graph, np.memmap) or isinstance(knowledge_graph, KG), \
             f"knowledge_graph must be an instance of KG or np.memmap. Currently {type(knowledge_graph)}"
         if self.args.num_folds_for_cv == 0:
@@ -424,7 +427,7 @@ class DICE_Trainer:
         :param dataset:
         :return: model
         """
-        print(f'{self.args.num_folds_for_cv}-fold cross-validation')
+        logger.info(f'{self.args.num_folds_for_cv}-fold cross-validation')
         # (1) Create Kfold data
         from sklearn.model_selection import KFold
         kf = KFold(n_splits=self.args.num_folds_for_cv, shuffle=True, random_state=1)
@@ -437,7 +440,7 @@ class DICE_Trainer:
             args = copy.copy(self.args)
             trainer = initialize_trainer(args, get_callbacks(args))
             model, form_of_labelling = select_model(vars(args), self.is_continual_training, self.storage_path)
-            print(f'{form_of_labelling} training starts: {model.name}')
+            logger.info(f'{form_of_labelling} training starts: {model.name}')
 
             train_set_for_i_th_fold, test_set_for_i_th_fold = dataset.train_set[train_index], dataset.train_set[
                 test_index]
@@ -457,8 +460,8 @@ class DICE_Trainer:
             eval_folds.append([res['MRR'], res['H@1'], res['H@3'], res['H@10']])
         eval_folds = pd.DataFrame(eval_folds, columns=['MRR', 'H@1', 'H@3', 'H@10'])
         self.evaluator.report = eval_folds.to_dict()
-        print(eval_folds)
-        print(eval_folds.describe())
+        logger.info(eval_folds)
+        logger.info(eval_folds.describe())
         # results = {'H@1': eval_folds['H@1'].mean(), 'H@3': eval_folds['H@3'].mean(), 'H@10': eval_folds['H@10'].mean(),
         #           'MRR': eval_folds['MRR'].mean()}
         # print(f'KFold Cross Validation Results: {results}')

--- a/dicee/trainer/model_parallelism.py
+++ b/dicee/trainer/model_parallelism.py
@@ -7,6 +7,7 @@ This module implements the tensor parallelism training strategy described in:
 The TensorParallel trainer creates an ensemble of models, each trained on a separate GPU,
 allowing efficient utilization of multi-GPU systems through model parallelism.
 """
+import logging
 from typing import Tuple
 
 import torch
@@ -15,6 +16,8 @@ from ..abstracts import AbstractTrainer
 from ..models.ensemble import EnsembleKGE
 from ..static_funcs_training import make_iterable_verbose
 from .auto_batch_finder import find_good_batch_size
+
+logger = logging.getLogger(__name__)
 
 
 def extract_input_outputs(z: list, device=None):
@@ -238,7 +241,7 @@ class TensorParallel(AbstractTrainer):
 
     combined_model.eval()
     combined_model.to("cpu")
-    print(f"Evaluating combined Ensemble of {combined_model_args['model']}")
+    logger.info(f"Evaluating combined Ensemble of {combined_model_args['model']}")
     eval_result = trainer.evaluator.eval(dataset=trainer.dataset,
                                         trained_model=combined_model,
                                         form_of_labelling=form_of_labelling,

--- a/dicee/trainer/torch_trainer.py
+++ b/dicee/trainer/torch_trainer.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from typing import Tuple
@@ -8,6 +9,8 @@ from tqdm import tqdm
 
 from dicee.abstracts import AbstractTrainer
 from dicee.trainer.auto_batch_finder import find_good_batch_size
+
+logger = logging.getLogger(__name__)
 
 
 class TorchTrainer(AbstractTrainer):
@@ -106,7 +109,7 @@ class TorchTrainer(AbstractTrainer):
                     persistent_workers=False,
                 )
 
-        print(f'NumOfDataPoints:{len(self.train_dataloaders.dataset)} '
+        logger.info(f'NumOfDataPoints:{len(self.train_dataloaders.dataset)} '
               f'| NumOfEpochs:{self.attributes.max_epochs} '
               f'| LearningRate:{self.model.learning_rate} '
               f'| BatchSize:{self.train_dataloaders.batch_size} '
@@ -200,6 +203,6 @@ class TorchTrainer(AbstractTrainer):
                 self.device)
             return (x_batch, y_idx_batch), y_batch
         else:
-            print(len(batch))
-            print("Unexpected batch shape..")
+            logger.error(len(batch))
+            logger.error("Unexpected batch shape..")
             raise RuntimeError

--- a/dicee/trainer/torch_trainer_ddp.py
+++ b/dicee/trainer/torch_trainer_ddp.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Iterable
 
@@ -8,6 +9,8 @@ from tqdm import tqdm
 
 from dicee.abstracts import AbstractTrainer
 from dicee.trainer.auto_batch_finder import find_good_batch_size
+
+logger = logging.getLogger(__name__)
 
 torch.set_float32_matmul_precision('high')
 
@@ -162,7 +165,7 @@ class NodeTrainer:
 
             except Exception as e:
                 if self.local_rank == 0:
-                    print(f"[DDP ERROR] Broadcast failed: {e}")
+                    logger.error(f"[DDP ERROR] Broadcast failed: {e}")
 
                 if dist.is_initialized():
                     dist.destroy_process_group()

--- a/dicee/trainer/torch_trainer_fsdp.py
+++ b/dicee/trainer/torch_trainer_fsdp.py
@@ -11,6 +11,7 @@ Dense parameters (relation embeddings, Clifford coefficients, …) are wrapped
 with FSDP and updated by the standard dense optimizer.
 """
 
+import logging
 import math
 import os
 import threading
@@ -30,6 +31,8 @@ from torch.utils.data import DataLoader
 
 from dicee.abstracts import AbstractTrainer
 from dicee.static_funcs_training import make_iterable_verbose
+
+logger = logging.getLogger(__name__)
 
 try:
     from torch._dynamo.eval_frame import OptimizedModule
@@ -228,7 +231,7 @@ class TorchFSDPTrainer(AbstractTrainer):
 
         if self.use_compile and hasattr(torch, "compile"):
             if self.local_rank == 0:
-                print("Compiling model with torch.compile...")
+                logger.info("Compiling model with torch.compile...")
             self.model = torch.compile(self.model, mode="reduce-overhead")
 
         num_of_batches = len(self.train_dataset_loader)

--- a/tests/test_unit_callbacks.py
+++ b/tests/test_unit_callbacks.py
@@ -8,6 +8,7 @@ Covers:
   at the configured interval
 """
 
+import logging
 import os
 import tempfile
 import types
@@ -91,17 +92,17 @@ class TestAccumulateEpochLossCallback:
 
 class TestPrintCallback:
 
-    def test_on_fit_start_runs_without_error(self, capsys):
+    def test_on_fit_start_runs_without_error(self, caplog):
         cb = PrintCallback()
-        cb.on_fit_start(trainer=_make_trainer(), pl_module=types.SimpleNamespace())
-        captured = capsys.readouterr()
-        assert "Training is starting" in captured.out
+        with caplog.at_level(logging.INFO, logger="dicee.callbacks"):
+            cb.on_fit_start(trainer=_make_trainer(), pl_module=types.SimpleNamespace())
+        assert "Training is starting" in caplog.text
 
-    def test_on_fit_end_prints_runtime(self, capsys):
+    def test_on_fit_end_prints_runtime(self, caplog):
         cb = PrintCallback()
-        cb.on_fit_end(trainer=_make_trainer(), pl_module=types.SimpleNamespace())
-        captured = capsys.readouterr()
-        assert "Training Runtime" in captured.out
+        with caplog.at_level(logging.INFO, logger="dicee.callbacks"):
+            cb.on_fit_end(trainer=_make_trainer(), pl_module=types.SimpleNamespace())
+        assert "Training Runtime" in caplog.text
 
     def test_on_train_batch_end_returns_none(self):
         cb = PrintCallback()


### PR DESCRIPTION
print() to logging

Asserts are stripped when Python runs with -O, so validation on the public KGE inference class (predict, predict_topk, answer_multi_hop_query, find_missing_triples, predict_literals, etc.) and the preprocessing pipeline silently disappeared in optimized mode. Converted the asserts guarding user input at these API boundaries to ValueError/TypeError with descriptive messages; internal tensor-shape sanity checks are left as asserts since they guard invariants, not user input.

Also migrated print() calls across the library to per-module logging.getLogger(__name__) so consumers embedding dicee in larger pipelines can control, silence, or redirect verbosity instead of monkeypatching stdout. Updated a unit test that asserted on captured stdout to use caplog instead, since the message it checks now goes through logging.