### PR TITLE
fix: improve TP trainer error message when insufficient GPUs

### DIFF
--- a/dicee/models/ensemble.py
+++ b/dicee/models/ensemble.py
@@ -8,6 +8,11 @@ class EnsembleKGE:
     def __init__(self, models : list=None, seed_model=None, pretrained_models:List=None):
 
         if models is not None:
+            if len(models) == 0:
+                raise ValueError(
+                    "EnsembleKGE requires at least one model. The models list is empty. "
+                    "This typically occurs when using Tensor Parallelism (TP) trainer without sufficient GPUs."
+                )
             self.models = nn.ModuleList()
             self.optimizers = []
             self.loss_history = []
@@ -20,6 +25,10 @@ class EnsembleKGE:
                 self.models.append(i_model)
         else:
             assert pretrained_models is not None
+            if len(pretrained_models) == 0:
+                raise ValueError(
+                    "EnsembleKGE requires at least one pretrained model. The pretrained_models list is empty."
+                )
             self.models = pretrained_models
             self.optimizers = []
             self.loss_history = []

--- a/dicee/static_funcs.py
+++ b/dicee/static_funcs.py
@@ -287,9 +287,17 @@ def select_model(args: dict, is_continual_training: bool = None, storage_path: s
     else:
         if args["trainer"]=="TP":
             # If it is tensor parallelized KGE, then we need to create ensemble of models.
+            num_gpus = torch.cuda.device_count()
+            if num_gpus < 2:
+                raise RuntimeError(
+                    f"Tensor Parallelism (TP) trainer requires at least 2 GPUs, but found {num_gpus}. "
+                    f"To use TP trainer, ensure your system has multiple GPUs available or switch to a different "
+                    f"trainer (e.g., 'torchCPUTrainer', 'PL', 'torchDDP', 'torchFSDP'). "
+                    f"Available GPUs: {torch.cuda.get_device_name(0) if num_gpus > 0 else 'None'}"
+                )
             models = []
             labelling_flag = None
-            for i in range(torch.cuda.device_count()):
+            for i in range(num_gpus):
                 args["random_seed"] = i
                 model, labelling_flag = intialize_model(args)
                 models.append(model)


### PR DESCRIPTION
- Add validation in select_model() to check GPU count before creating EnsembleKGE
- Raise clear RuntimeError with actionable guidance for TP trainer GPU requirements
- Add safety check in EnsembleKGE.__init__() for empty models list
- Suggest alternative trainers when TP requirements not met
- Improves error UX from cryptic IndexError to informative error message