### PR TITLE
feat: configurable --log_level CLI flag; document logging and polish README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<div align="center">
+
+![dicee_logo](docs/_static/images/dicee_logo.png)
+
+# DICE Embeddings
+
+**Hardware-agnostic Framework for Large-scale Knowledge Graph Embeddings**
+
 [![Downloads](https://static.pepy.tech/badge/dicee)](https://pepy.tech/project/dicee)
 [![Downloads](https://img.shields.io/pypi/dm/dicee)](https://pypi.org/project/dicee/)
 [![Coverage](https://img.shields.io/badge/coverage-54%25-green)](https://dice-group.github.io/dice-embeddings/usage/main.html#coverage-report)
@@ -5,26 +13,28 @@
 [![Docs](https://img.shields.io/badge/documentation-0.3.2-yellow)](https://dice-group.github.io/dice-embeddings/index.html)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dice-group/dice-embeddings)
 
-![dicee_logo](docs/_static/images/dicee_logo.png)
+</div>
 
-# DICE Embeddings: Hardware-agnostic Framework for Large-scale Knowledge Graph Embeddings
+Knowledge graph embedding research has mainly focused on learning continuous representations of knowledge graphs towards the link prediction problem. Recently developed frameworks can be effectively applied in a wide range of research-related applications, yet using them in real-world settings becomes more challenging as the knowledge graph grows.
+
+**dicee** computes embeddings for knowledge graphs of any size — from a few hundred triples to knowledge graphs with hundreds of millions of entities — running on a single CPU or scaled across GPUs and nodes, without changing a line of model code.
+
+- 🧩 **30+ models** — real, complex, quaternion, octonion, and Clifford-algebra scoring functions, plus any [PyKEEN](https://github.com/pykeen/pykeen) model
+- ⚙️ **Any hardware** — CPU, single/multi-GPU, native DDP, FSDP, and Tensor Parallelism
+- 📈 **Scales up** — row-wise sharded entity tables and distributed optimizer states for very large knowledge graphs
+- 🔌 **Two entry points** — the `dicee` CLI for quick runs, and a Python API (`Execute`, `KGE`) for programmatic control
 
 ## Quick Reference
 
-| Feature | Command/Code |
-|---------|-------------|
-| **Install (CPU)** | `pip install dicee --extra-index-url https://download.pytorch.org/whl/cpu` |
-| **Install (GPU)** | `pip install dicee` |
-| **Train model** | `dicee --dataset_dir "KGs/UMLS" --model Keci` |
-| **Load pretrained** | `from dicee import KGE; model = KGE(path='...')` |
-| **Predict links** | `model.predict_topk(h=["entity"], r=["relation"], topk=10)` |
+| Task | Command |
+|------|---------|
+| 📦 **Install (CPU)** | `pip install dicee --extra-index-url https://download.pytorch.org/whl/cpu` |
+| 📦 **Install (GPU)** | `pip install dicee` |
+| 🚀 **Train a model** | `dicee --dataset_dir "KGs/UMLS" --model Keci` |
+| 📂 **Load a pretrained model** | `from dicee import KGE; model = KGE(path='...')` |
+| 🔮 **Predict links** | `model.predict_topk(h=["entity"], r=["relation"], topk=10)` |
 
-Knowledge graph embedding research has mainly focused on learning continuous representations of knowledge graphs towards the link prediction problem. 
-Recently developed frameworks can be effectively applied in a wide range of research-related applications.
-Yet, using these frameworks in real-world applications becomes more challenging as the size of the knowledge graph grows.
-
-We developed the DICE Embeddings framework (dicee) to compute embeddings for large-scale knowledge graphs in a hardware-agnostic manner.
-## For more please visit [dice-embeddings](https://dice-group.github.io/dice-embeddings/)!
+📖 For more, visit the [dicee documentation](https://dice-group.github.io/dice-embeddings/)!
 
 ## Installation
 <details><summary> Click me! </summary>
@@ -94,6 +104,37 @@ OMP_NUM_THREADS=1 torchrun --standalone --nnodes=1 --nproc_per_node=gpu dicee --
 
 ```
 
+#### Logging
+<details><summary> Click me! </summary>
+
+Progress, timing, and checkpoint messages (dataset info, epoch loss, "Saving model...", etc.) are emitted through Python's standard `logging` module rather than `print()`. By default `--log_level` is `INFO`, so these messages are shown, matching the classic CLI output.
+
+```bash
+# Default: INFO messages (dataset stats, timings, checkpoints, ...) are printed to stderr
+dicee --dataset_dir "KGs/UMLS" --model Keci
+
+# Quieter: only show warnings and errors (e.g. on noisy multi-node/multi-GPU logs)
+dicee --dataset_dir "KGs/UMLS" --model Keci --log_level WARNING
+
+# Silent: only errors are shown
+dicee --dataset_dir "KGs/UMLS" --model Keci --log_level ERROR
+
+# Verbose: include DEBUG-level messages too
+dicee --dataset_dir "KGs/UMLS" --model Keci --log_level DEBUG
+```
+
+`--log_level` accepts `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. The same setting is available when training from Python via `dicee.config.Namespace`:
+
+```python
+from dicee.executer import Execute
+from dicee.config import Namespace
+args = Namespace()
+args.dataset_dir = "KGs/UMLS"
+args.log_level = "WARNING"  # silence INFO-level progress messages
+Execute(args).start()
+```
+Since every rank in a distributed run (`torchDDP`/`torchFSDP`/`PL` with multiple GPUs or nodes) configures its own logger, each process prints its own messages; lower the level to `WARNING` or `ERROR` to cut down on duplicate output across ranks.
+
 A KGE model model can also be trained in multi-node multi-gpu DDP setting. 
 ```bash
 torchrun --nnodes 2 --nproc_per_node=gpu  --node_rank 0 --rdzv_id 455 --rdzv_backend c10d --rdzv_endpoint=nebula  dicee --trainer "torchDDP" --dataset_dir "KGs/YAGO3-10" --path_to_store_single_run "YAGO3_torchDDP"
@@ -104,6 +145,7 @@ Multi-node training is also possible with the `PL` trainer
 torchrun --nnodes 2 --nproc_per_node=gpu  --node_rank 0 --rdzv_id 455 --rdzv_backend c10d --rdzv_endpoint=nebula  dicee --trainer "PL" --dataset_dir "KGs/YAGO3-10" --path_to_store_single_run "YAGO3_PL"
 torchrun --nnodes 2 --nproc_per_node=gpu  --node_rank 1 --rdzv_id 455 --rdzv_backend c10d --rdzv_endpoint=nebula  dicee --trainer "PL" --dataset_dir "KGs/YAGO3-10" --path_to_store_single_run "YAGO3_PL"
 ```
+</details>
 
 #### FSDP Training (large entity tables)
 

--- a/dicee/config.py
+++ b/dicee/config.py
@@ -105,6 +105,10 @@ class Namespace(argparse.Namespace):
         self.random_seed: int = 0
         "Random Seed"
 
+        self.log_level: str = "INFO"
+        """Logging verbosity: DEBUG, INFO, WARNING, ERROR, or CRITICAL. Dataset info, timing, and
+        checkpoint messages are logged at INFO; set to WARNING or higher to silence them."""
+
         self.sample_triples_ratio: Optional[float] = None
         """Read some triples that are uniformly at random sampled. Ratio being between 0 and 1"""
 

--- a/dicee/executer.py
+++ b/dicee/executer.py
@@ -67,6 +67,13 @@ class Execute:
             args: Configuration arguments (Namespace or similar).
             continuous_training: Whether this is continual training.
         """
+        # Configure logging verbosity as early as possible so that dataset/timing/checkpoint
+        # messages logged during distributed setup and KG loading are not silently dropped.
+        logging.basicConfig(
+            level=getattr(logging, str(getattr(args, "log_level", "INFO")).upper(), logging.INFO),
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+            force=True,
+        )
         # Setup distributed and device ranks before training
         distributed_setup = setup_distributed_training(args)
         # Checks if the current training setup is distributed

--- a/dicee/scripts/run.py
+++ b/dicee/scripts/run.py
@@ -94,6 +94,10 @@ def get_default_arguments(description=None):
                         help='Number of cores to be used. 0 implies using single CPU')
     parser.add_argument("--random_seed", type=int, default=1,
                         help='Seed for all, see pl seed_everything().')
+    parser.add_argument("--log_level", type=str, default="INFO",
+                        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                        help='Logging verbosity. Dataset info, timing, and checkpoint messages are '
+                             'logged at INFO; set to WARNING or higher to silence them.')
     parser.add_argument('--p', type=int, default=0,
                         help='P for Clifford Algebra')
     parser.add_argument('--q', type=int, default=1,


### PR DESCRIPTION
## Summary
- Closes the logging regression raised in a side-thread of dice-group/dice-embeddings#422: the `print()` → `logging` migration never called `logging.basicConfig()` anywhere, so INFO-level messages (dataset stats, timings, "Saving model...", etc.) were silently dropped by default — exactly what `sshivam95` and `sapkotaruz11` hit ("people are expecting to see things printed").
- Adds `--log_level` (CLI, `dicee/scripts/run.py`) and `Namespace.log_level` (`dicee/config.py`), default `INFO`. `Execute.__init__` now calls `logging.basicConfig()` from it as the very first thing it does, restoring the old print-like visibility by default while making it configurable (`WARNING`/`ERROR`/`CRITICAL` to quiet noisy multi-rank distributed runs, `DEBUG` for more detail).
- Documents enabling/disabling logging (CLI flag + Python API) in a new README "Logging" section.
- Polishes the README header: centered logo/title/badges, a tighter tagline, scannable feature bullets, and a cleaned-up Quick Reference table.

## Test plan
- [x] `ruff check dicee/executer.py dicee/config.py dicee/scripts/run.py --line-length=200` passes.
- [x] Manually ran `dicee --dataset_dir "KGs/UMLS" --model Keci ...` with default `--log_level`: INFO messages (dataset description, timings, trainer init) are visible, matching the pre-regression behavior.
- [x] Same run with `--log_level ERROR`: INFO/WARNING messages are fully suppressed.
- [x] `python -m pytest tests/test_execute_start.py -q`: 7 passed.
- [x] Broader non-GPU/non-distributed suite: 153 passed, 1 pre-existing failure (`TestRegressionTensorParallel::test_k_vs_all`, requires ≥2 GPUs — this machine has 1, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)